### PR TITLE
tests + impl(#107): Preflight (openapi version field)

### DIFF
--- a/src/compile/preflight.ts
+++ b/src/compile/preflight.ts
@@ -1,0 +1,223 @@
+/**
+ * Pre-flight check on the `openapi` version field of a source document.
+ *
+ * Closes #107. Reads at most {@link MAX_PREFLIGHT_BYTES} from the source,
+ * extracts the OpenAPI version, classifies dialect (3.0 vs 3.1), and
+ * either resolves with `{origin, dialect, version}` or rejects with a
+ * specific {@link Compile} error class.
+ *
+ * Source can be:
+ *   - a filesystem path (`string` not starting with `http`/`file`)
+ *   - a `URL` (file:// or remote)
+ *   - a `ReadableStream<Uint8Array>` (e.g. stdin)
+ *
+ * Pre-flight is deliberately lightweight: a regex scan of the first few
+ * KiB of bytes after BOM strip. The full document is not parsed; that's
+ * hey-api's job downstream.
+ *
+ * Stream sources: the reader's lock is released after the budget is hit,
+ * not cancelled, so the underlying stream object remains valid. The
+ * bytes already consumed are gone — see #107 tech-spec §7 and the
+ * "Open questions" entry on stream handoff for the architectural
+ * follow-up that will tee or buffer for hey-api.
+ *
+ * @module
+ */
+
+/** Maximum bytes pre-flight reads from any source. Spec default: 16 KiB. */
+export const MAX_PREFLIGHT_BYTES = 16 * 1024;
+
+/**
+ * Strict X.Y.Z shape for accepted versions: major 3, minor 0 or 1, patch
+ * is a non-negative integer with no leading zero. Per #107 tech-spec §6
+ * this excludes `3.0` (no patch), `3.0.01` (zero-padded), `3.1.0-rc1`
+ * (prerelease), `3.2.0`, `4.0.0`. Future patches like `3.0.5` or
+ * `3.1.3` are accepted automatically.
+ */
+const SUPPORTED_RE = /^3\.[01]\.(?:0|[1-9]\d*)$/;
+const SUPPORTED_DESC = "3.0.x or 3.1.x";
+
+/** Compile-stage error classes. All carry an `origin` field. */
+export const Compile = {
+  MissingVersion: class extends Error {
+    origin: string;
+    constructor(origin: string, message?: string) {
+      super(message ?? `OpenAPI version field missing in ${origin}`);
+      this.name = "Compile.MissingVersion";
+      this.origin = origin;
+    }
+  },
+  InvalidVersion: class extends Error {
+    origin: string;
+    constructor(origin: string, message?: string) {
+      super(message ?? `OpenAPI version field is not a string in ${origin}`);
+      this.name = "Compile.InvalidVersion";
+      this.origin = origin;
+    }
+  },
+  UnsupportedVersion: class extends Error {
+    origin: string;
+    constructor(origin: string, version: string, message?: string) {
+      super(
+        message ??
+          `OpenAPI version ${version} is unsupported in ${origin}. Supported: ${SUPPORTED_DESC}.`,
+      );
+      this.name = "Compile.UnsupportedVersion";
+      this.origin = origin;
+    }
+  },
+  HeyApiFailure: class extends Error {
+    origin: string;
+    constructor(origin: string, cause: unknown, message?: string) {
+      super(message ?? `hey-api rejected ${origin}: ${String(cause)}`);
+      this.name = "Compile.HeyApiFailure";
+      this.origin = origin;
+      // @ts-ignore Error cause is widely supported.
+      this.cause = cause;
+    }
+  },
+};
+
+export type PreflightResult = {
+  origin: string;
+  dialect: "3.0" | "3.1";
+  version: string;
+};
+
+/** Strip a leading UTF-8 BOM (EF BB BF) if present. */
+function strip(text: string): string {
+  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+/** Read a source down to MAX_PREFLIGHT_BYTES, returning bytes + origin string. */
+async function read(
+  src: string | URL | ReadableStream<Uint8Array>,
+): Promise<{ bytes: Uint8Array; origin: string }> {
+  if (src instanceof ReadableStream) {
+    return { bytes: await readStream(src), origin: "<stdin>" };
+  }
+  if (src instanceof URL) {
+    const origin = src.toString();
+    if (src.protocol === "file:") {
+      return { bytes: await readFile(src), origin };
+    }
+    const res = await fetch(src);
+    if (!res.body) return { bytes: new Uint8Array(), origin };
+    return { bytes: await readStream(res.body), origin };
+  }
+  if (src.startsWith("http://") || src.startsWith("https://")) {
+    const url = new URL(src);
+    const res = await fetch(url);
+    if (!res.body) return { bytes: new Uint8Array(), origin: src };
+    return { bytes: await readStream(res.body), origin: src };
+  }
+  const path = src.startsWith("file:") ? new URL(src) : src;
+  return { bytes: await readFile(path), origin: src };
+}
+
+async function readFile(path: string | URL): Promise<Uint8Array> {
+  const f = await Deno.open(path, { read: true });
+  try {
+    const buf = new Uint8Array(MAX_PREFLIGHT_BYTES);
+    let total = 0;
+    while (total < MAX_PREFLIGHT_BYTES) {
+      const n = await f.read(buf.subarray(total));
+      if (n === null) break;
+      total += n;
+    }
+    return buf.subarray(0, total);
+  } finally {
+    f.close();
+  }
+}
+
+async function readStream(s: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const reader = s.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < MAX_PREFLIGHT_BYTES) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    // Release the lock without cancelling: keeps the underlying stream
+    // alive for downstream consumers that may want the remaining bytes
+    // (per #107 tech-spec §7 — the spec gap on stream handoff is
+    // tracked separately; not destroying the stream here is the
+    // minimum-viable behaviour).
+    try {
+      reader.releaseLock();
+    } catch { /* ignore */ }
+  }
+  const out = new Uint8Array(Math.min(total, MAX_PREFLIGHT_BYTES));
+  let offset = 0;
+  for (const chunk of chunks) {
+    if (offset >= out.byteLength) break;
+    const take = Math.min(chunk.byteLength, out.byteLength - offset);
+    out.set(chunk.subarray(0, take), offset);
+    offset += take;
+  }
+  return out;
+}
+
+/**
+ * Extract the `openapi:` field's RAW value. Tries the JSON form first
+ * (string-quoted, anchored to `{` or `,`), then the YAML form (key at
+ * the start of a logical line, optional quotes, value runs to whitespace
+ * or `#` comment).
+ *
+ * Returns:
+ *   - `{kind: "missing"}` — no `openapi:` line found
+ *   - `{kind: "non-string", raw}` — bare integer (`openapi: 3`)
+ *   - `{kind: "string", raw}` — version string
+ */
+function extract(text: string):
+  | { kind: "missing" }
+  | { kind: "non-string"; raw: string }
+  | { kind: "string"; raw: string } {
+  // JSON form: `"openapi": "<value>"` after `{` or `,`. Per #107 §3.
+  const json = text.match(/^\s*[{,]\s*"openapi"\s*:\s*"([^"]+)"/m);
+  if (json) {
+    return { kind: "string", raw: json[1].trim() };
+  }
+  // YAML form: top-level `openapi: ...` line. Stop at whitespace, quote,
+  // or `#` comment per #107 §3.
+  const yaml = text.match(/^\s*openapi\s*:\s*(['"]?)([^\s'"#]+)\1/m);
+  if (!yaml) return { kind: "missing" };
+  const quoted = yaml[1] !== "";
+  const raw = yaml[2];
+  // YAML scalar: a bare integer parses as a number (not a string).
+  // `openapi: 3` is the InvalidVersion case; `openapi: "3"` is a string.
+  if (!quoted && /^\d+$/.test(raw)) {
+    return { kind: "non-string", raw };
+  }
+  return { kind: "string", raw };
+}
+
+/**
+ * Pre-flight check entry point. See module docstring.
+ */
+export const Preflight = {
+  async check(src: string | URL | ReadableStream<Uint8Array>): Promise<PreflightResult> {
+    const { bytes, origin } = await read(src);
+    const text = strip(new TextDecoder("utf-8").decode(bytes));
+
+    const field = extract(text);
+    if (field.kind === "missing") {
+      throw new Compile.MissingVersion(origin);
+    }
+    if (field.kind === "non-string") {
+      throw new Compile.InvalidVersion(origin);
+    }
+    const version = field.raw;
+    if (!SUPPORTED_RE.test(version)) {
+      throw new Compile.UnsupportedVersion(origin, version);
+    }
+    const dialect: "3.0" | "3.1" = version.startsWith("3.0") ? "3.0" : "3.1";
+    return { origin, dialect, version };
+  },
+};

--- a/src/compile/preflight.ts
+++ b/src/compile/preflight.ts
@@ -84,11 +84,6 @@ export type PreflightResult = {
   version: string;
 };
 
-/** Strip a leading UTF-8 BOM (EF BB BF) if present. */
-function strip(text: string): string {
-  return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
-}
-
 /** Read a source down to MAX_PREFLIGHT_BYTES, returning bytes + origin string. */
 async function read(
   src: string | URL | ReadableStream<Uint8Array>,
@@ -103,13 +98,23 @@ async function read(
     }
     const res = await fetch(src);
     if (!res.body) return { bytes: new Uint8Array(), origin };
-    return { bytes: await readStream(res.body), origin };
+    const bytes = await readStream(res.body);
+    // Cancel the unread remainder so the HTTP connection isn't kept
+    // open after pre-flight stops reading.
+    try {
+      await res.body.cancel();
+    } catch { /* ignore — already drained or locked */ }
+    return { bytes, origin };
   }
   if (src.startsWith("http://") || src.startsWith("https://")) {
     const url = new URL(src);
     const res = await fetch(url);
     if (!res.body) return { bytes: new Uint8Array(), origin: src };
-    return { bytes: await readStream(res.body), origin: src };
+    const bytes = await readStream(res.body);
+    try {
+      await res.body.cancel();
+    } catch { /* ignore */ }
+    return { bytes, origin: src };
   }
   const path = src.startsWith("file:") ? new URL(src) : src;
   return { bytes: await readFile(path), origin: src };
@@ -166,21 +171,26 @@ async function readStream(s: ReadableStream<Uint8Array>): Promise<Uint8Array> {
 
 /**
  * Extract the `openapi:` field's RAW value. Tries the JSON form first
- * (string-quoted, anchored to `{` or `,`), then the YAML form (key at
- * the start of a logical line, optional quotes, value runs to whitespace
- * or `#` comment).
+ * (string-quoted, after `{` or `,`), then the YAML form (key at
+ * line start, optional quotes, value runs to whitespace / quote / `#`).
+ *
+ * Exported for direct unit testing of the parser without I/O — the
+ * effectful `Preflight.check` path tests via fixtures, but `extract`
+ * itself is a pure function.
  *
  * Returns:
  *   - `{kind: "missing"}` — no `openapi:` line found
  *   - `{kind: "non-string", raw}` — bare integer (`openapi: 3`)
  *   - `{kind: "string", raw}` — version string
  */
-function extract(text: string):
+export function extract(text: string):
   | { kind: "missing" }
   | { kind: "non-string"; raw: string }
   | { kind: "string"; raw: string } {
-  // JSON form: `"openapi": "<value>"` after `{` or `,`. Per #107 §3.
-  const json = text.match(/^\s*[{,]\s*"openapi"\s*:\s*"([^"]+)"/m);
+  // JSON form: `"openapi": "<value>"` preceded by `{` or `,`. The
+  // anchor matches `{` for openapi-as-first-key OR `,` for any later
+  // position; both forms occur in real-world OpenAPI JSON.
+  const json = text.match(/[{,]\s*"openapi"\s*:\s*"([^"]+)"/);
   if (json) {
     return { kind: "string", raw: json[1].trim() };
   }
@@ -204,7 +214,8 @@ function extract(text: string):
 export const Preflight = {
   async check(src: string | URL | ReadableStream<Uint8Array>): Promise<PreflightResult> {
     const { bytes, origin } = await read(src);
-    const text = strip(new TextDecoder("utf-8").decode(bytes));
+    // TextDecoder strips a leading UTF-8 BOM by default (ignoreBOM=false).
+    const text = new TextDecoder("utf-8").decode(bytes);
 
     const field = extract(text);
     if (field.kind === "missing") {

--- a/src/compile/preflight.ts
+++ b/src/compile/preflight.ts
@@ -96,28 +96,27 @@ async function read(
     if (src.protocol === "file:") {
       return { bytes: await readFile(src), origin };
     }
-    const res = await fetch(src);
-    if (!res.body) return { bytes: new Uint8Array(), origin };
-    const bytes = await readStream(res.body);
-    // Cancel the unread remainder so the HTTP connection isn't kept
-    // open after pre-flight stops reading.
-    try {
-      await res.body.cancel();
-    } catch { /* ignore — already drained or locked */ }
-    return { bytes, origin };
+    return { bytes: await fetchBytes(src), origin };
   }
   if (src.startsWith("http://") || src.startsWith("https://")) {
-    const url = new URL(src);
-    const res = await fetch(url);
-    if (!res.body) return { bytes: new Uint8Array(), origin: src };
-    const bytes = await readStream(res.body);
-    try {
-      await res.body.cancel();
-    } catch { /* ignore */ }
-    return { bytes, origin: src };
+    return { bytes: await fetchBytes(new URL(src)), origin: src };
   }
   const path = src.startsWith("file:") ? new URL(src) : src;
   return { bytes: await readFile(path), origin: src };
+}
+
+async function fetchBytes(url: URL): Promise<Uint8Array> {
+  const res = await fetch(url);
+  if (!res.body) return new Uint8Array();
+  // Always cancel the body, even if readStream throws — leaving the
+  // HTTP connection un-cancelled would keep it open.
+  try {
+    return await readStream(res.body);
+  } finally {
+    try {
+      await res.body.cancel();
+    } catch { /* ignore — already drained, locked, or aborted */ }
+  }
 }
 
 async function readFile(path: string | URL): Promise<Uint8Array> {
@@ -187,10 +186,12 @@ export function extract(text: string):
   | { kind: "missing" }
   | { kind: "non-string"; raw: string }
   | { kind: "string"; raw: string } {
-  // JSON form: `"openapi": "<value>"` preceded by `{` or `,`. The
-  // anchor matches `{` for openapi-as-first-key OR `,` for any later
-  // position; both forms occur in real-world OpenAPI JSON.
-  const json = text.match(/[{,]\s*"openapi"\s*:\s*"([^"]+)"/);
+  // JSON form per #107 §3: `^\s*[{,]\s*"openapi"\s*:\s*"<value>"`.
+  // Anchored to a logical line start so a stray `{"openapi": ...}`
+  // inside a YAML description block can't hijack the result. The `\s*`
+  // run between the brace/comma and the `"openapi"` matches across
+  // newlines, so multi-line JSON pretty-printing still resolves.
+  const json = text.match(/^\s*[{,]\s*"openapi"\s*:\s*"([^"]+)"/m);
   if (json) {
     return { kind: "string", raw: json[1].trim() };
   }

--- a/tests/compile/openapi-version_test.ts
+++ b/tests/compile/openapi-version_test.ts
@@ -1,0 +1,268 @@
+/**
+ * Red-Gate tests for clesty/sw2m issue #107: `openapi` version field.
+ *
+ * Phase 2a per philosophies §II — these tests are written BEFORE the
+ * implementation. They are EXPECTED TO FAIL because `src/compile/preflight.ts`
+ * does not exist yet. That failure is the Red signal: it proves the tests
+ * are real and load-bearing.
+ *
+ * Implementation contract under test (from #107 tech spec):
+ *   class Preflight {
+ *     static check(src: string | URL | ReadableStream):
+ *       Promise<{ origin: string; dialect: "3.0" | "3.1"; version: string }>;
+ *   }
+ *
+ * Errors (named classes on the `Compile` namespace):
+ *   - Compile.MissingVersion
+ *   - Compile.InvalidVersion
+ *   - Compile.UnsupportedVersion
+ *   - Compile.HeyApiFailure
+ *
+ * The import below is wrapped in a try/catch so the test file is
+ * typecheck-tolerant of the missing module: `deno task test` runs, every
+ * test fails with "Preflight not implemented yet — Red Gate", and the
+ * failure count matches the test count. That is a clean Red signal.
+ */
+
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// deno-lint-ignore no-explicit-any
+let Preflight: any;
+// deno-lint-ignore no-explicit-any
+let Compile: any;
+
+try {
+  const mod = await import("../../src/compile/preflight.ts");
+  Preflight = mod.Preflight;
+  Compile = mod.Compile;
+} catch {
+  Preflight = null;
+  Compile = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/compile-openapi-version/", import.meta.url),
+);
+
+function fixturePath(name: string): string {
+  return `${FIXTURE_DIR}${name}`;
+}
+
+function requireImpl(): void {
+  if (!Preflight || !Compile) {
+    throw new Error("Preflight not implemented yet — Red Gate");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Acceptance fixtures: pre-flight passes; pipeline reaches hey-api step.
+//    The spec says "use a hey-api stub or --dry-run to avoid slow codegen."
+//    Here we assert only the pre-flight contract: `Preflight.check` resolves
+//    with the expected dialect/version triple. Reaching the hey-api step is
+//    covered by the integration test (item 7, ignored below).
+// ---------------------------------------------------------------------------
+
+const ACCEPTANCE: Array<{ file: string; version: string; dialect: "3.0" | "3.1" }> = [
+  { file: "v300.yaml", version: "3.0.0", dialect: "3.0" },
+  { file: "v301.yaml", version: "3.0.1", dialect: "3.0" },
+  { file: "v302.yaml", version: "3.0.2", dialect: "3.0" },
+  { file: "v303.yaml", version: "3.0.3", dialect: "3.0" },
+  { file: "v304.yaml", version: "3.0.4", dialect: "3.0" },
+  { file: "v310.yaml", version: "3.1.0", dialect: "3.1" },
+  { file: "v311.yaml", version: "3.1.1", dialect: "3.1" },
+  { file: "v312.yaml", version: "3.1.2", dialect: "3.1" },
+];
+
+for (const { file, version, dialect } of ACCEPTANCE) {
+  Deno.test(`acceptance: ${file} (openapi ${version}) passes pre-flight`, async () => {
+    requireImpl();
+    const result = await Preflight.check(fixturePath(file));
+    assertEquals(result.version, version);
+    assertEquals(result.dialect, dialect);
+    assertStringIncludes(result.origin, file);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 2. Refusal fixtures: pre-flight fails with the matching Compile.* error.
+// ---------------------------------------------------------------------------
+
+const REFUSAL: Array<
+  { file: string; error: "MissingVersion" | "InvalidVersion" | "UnsupportedVersion" }
+> = [
+  { file: "swagger2.yaml", error: "MissingVersion" },
+  { file: "missing.yaml", error: "MissingVersion" },
+  { file: "v4.yaml", error: "UnsupportedVersion" },
+  { file: "v32.yaml", error: "UnsupportedVersion" },
+  { file: "zero-padded.yaml", error: "UnsupportedVersion" },
+  { file: "prerelease.yaml", error: "UnsupportedVersion" },
+  { file: "partial.yaml", error: "UnsupportedVersion" },
+  { file: "non-string.yaml", error: "InvalidVersion" },
+];
+
+for (const { file, error } of REFUSAL) {
+  Deno.test(`refusal: ${file} fails pre-flight with Compile.${error}`, async () => {
+    requireImpl();
+    let thrown: unknown = null;
+    try {
+      await Preflight.check(fixturePath(file));
+    } catch (err) {
+      thrown = err;
+    }
+    if (thrown === null) {
+      throw new Error(`expected Compile.${error}, got no error`);
+    }
+    const ErrCtor = Compile[error];
+    if (!(thrown instanceof ErrCtor)) {
+      throw new Error(
+        `expected instance of Compile.${error}, got ${
+          (thrown as { constructor?: { name?: string } })?.constructor?.name
+        }`,
+      );
+    }
+    // origin must be present on every Compile.* error per the spec.
+    assertStringIncludes((thrown as { origin: string }).origin, file);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 3. JSON / YAML parity: v300.json and v300.yaml both pass pre-flight
+//    identically (same version, same dialect).
+// ---------------------------------------------------------------------------
+
+Deno.test("parity: v300.json and v300.yaml produce identical pre-flight result", async () => {
+  requireImpl();
+  const yamlResult = await Preflight.check(fixturePath("v300.yaml"));
+  const jsonResult = await Preflight.check(fixturePath("v300.json"));
+  assertEquals(yamlResult.version, jsonResult.version);
+  assertEquals(yamlResult.dialect, jsonResult.dialect);
+  assertEquals(yamlResult.version, "3.0.0");
+  assertEquals(yamlResult.dialect, "3.0");
+});
+
+// ---------------------------------------------------------------------------
+// 4. BOM: bom-v300.yaml passes pre-flight (leading UTF-8 BOM stripped).
+// ---------------------------------------------------------------------------
+
+Deno.test("bom: bom-v300.yaml passes pre-flight after BOM strip", async () => {
+  requireImpl();
+  const result = await Preflight.check(fixturePath("bom-v300.yaml"));
+  assertEquals(result.version, "3.0.0");
+  assertEquals(result.dialect, "3.0");
+});
+
+// ---------------------------------------------------------------------------
+// 5. `origin` populated on errors for path, URL, and stdin sources.
+// ---------------------------------------------------------------------------
+
+Deno.test("origin: file path source — refusal carries path in origin", async () => {
+  requireImpl();
+  let thrown: unknown = null;
+  try {
+    await Preflight.check(fixturePath("v4.yaml"));
+  } catch (err) {
+    thrown = err;
+  }
+  if (thrown === null) throw new Error("expected refusal");
+  assertStringIncludes((thrown as { origin: string }).origin, "v4.yaml");
+});
+
+Deno.test("origin: URL source — refusal carries URL string in origin", async () => {
+  requireImpl();
+  const url = new URL("v4.yaml", new URL(FIXTURE_DIR, "file://"));
+  let thrown: unknown = null;
+  try {
+    await Preflight.check(url);
+  } catch (err) {
+    thrown = err;
+  }
+  if (thrown === null) throw new Error("expected refusal");
+  assertStringIncludes((thrown as { origin: string }).origin, "v4.yaml");
+});
+
+Deno.test("origin: stdin/stream source — refusal carries '<stdin>' in origin", async () => {
+  requireImpl();
+  // Spec: stream identifier is "<stdin>" for an unnamed ReadableStream source.
+  const bytes = new TextEncoder().encode(
+    "openapi: 4.0.0\ninfo:\n  title: x\n  version: 0\npaths: {}\n",
+  );
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  let thrown: unknown = null;
+  try {
+    await Preflight.check(stream);
+  } catch (err) {
+    thrown = err;
+  }
+  if (thrown === null) throw new Error("expected refusal");
+  assertEquals((thrown as { origin: string }).origin, "<stdin>");
+});
+
+// ---------------------------------------------------------------------------
+// 6. Pre-flight does not read more than MAX_PREFLIGHT_BYTES from the source.
+//    Assertable via a fake ReadableStream that throws after that count.
+//    The spec defines the default at 16 KiB.
+// ---------------------------------------------------------------------------
+
+Deno.test("budget: pre-flight reads at most MAX_PREFLIGHT_BYTES (16 KiB) from source", async () => {
+  requireImpl();
+  const MAX = 16 * 1024;
+  // Header that satisfies pre-flight in the first chunk.
+  const header = new TextEncoder().encode(
+    "openapi: 3.0.0\ninfo:\n  title: budget\n  version: 0\npaths: {}\n",
+  );
+  let bytesRead = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (bytesRead === 0) {
+        bytesRead += header.byteLength;
+        controller.enqueue(header);
+        return;
+      }
+      // Any subsequent pull beyond MAX must not happen. Trip a tripwire.
+      if (bytesRead > MAX) {
+        controller.error(new Error("pre-flight read past MAX_PREFLIGHT_BYTES"));
+        return;
+      }
+      // Pad up to MAX with zeros; pre-flight should stop before consuming all of it.
+      const remaining = MAX - bytesRead;
+      const chunk = new Uint8Array(Math.min(1024, remaining));
+      bytesRead += chunk.byteLength;
+      controller.enqueue(chunk);
+      if (bytesRead >= MAX) controller.close();
+    },
+  });
+
+  const result = await Preflight.check(stream);
+  assertEquals(result.version, "3.0.0");
+});
+
+// ---------------------------------------------------------------------------
+// 7. hey-api error wrapping: when hey-api itself rejects a doc that passed
+//    pre-flight, the resulting Compile.HeyApiFailure includes `origin` and
+//    the underlying error message.
+//
+//    Ignored: this requires the compile-pipeline integration harness (a
+//    hey-api stub or full pipeline driver), which is out of scope for the
+//    Red Gate. Enable when that harness lands.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "hey-api: a hey-api rejection is wrapped as Compile.HeyApiFailure with origin",
+  () => {
+    // TODO: enable when compile pipeline integration harness lands.
+    // Plan:
+    //   1. Stand up a hey-api stub that throws a known error for a fixture
+    //      that passes pre-flight (e.g. v300.yaml with a deliberately broken
+    //      $ref).
+    //   2. Drive the compile pipeline against that fixture.
+    //   3. Assert the surfaced error is `Compile.HeyApiFailure`, that
+    //      `error.origin` matches the fixture path, and that the underlying
+    //      hey-api error message is included (cause / wrapped message).
+  },
+);

--- a/tests/fixtures/compile-openapi-version/bom-v300.yaml
+++ b/tests/fixtures/compile-openapi-version/bom-v300.yaml
@@ -1,0 +1,5 @@
+﻿openapi: 3.0.0
+info:
+  title: BOM V300
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/missing.yaml
+++ b/tests/fixtures/compile-openapi-version/missing.yaml
@@ -1,0 +1,4 @@
+info:
+  title: Missing
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/non-string.yaml
+++ b/tests/fixtures/compile-openapi-version/non-string.yaml
@@ -1,0 +1,5 @@
+openapi: 3
+info:
+  title: Non-string
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/partial.yaml
+++ b/tests/fixtures/compile-openapi-version/partial.yaml
@@ -1,0 +1,5 @@
+openapi: "3.0"
+info:
+  title: Partial
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/prerelease.yaml
+++ b/tests/fixtures/compile-openapi-version/prerelease.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0-rc1
+info:
+  title: Prerelease
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/swagger2.yaml
+++ b/tests/fixtures/compile-openapi-version/swagger2.yaml
@@ -1,0 +1,5 @@
+swagger: "2.0"
+info:
+  title: Swagger 2.0
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v300.json
+++ b/tests/fixtures/compile-openapi-version/v300.json
@@ -1,0 +1,8 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "V300 (JSON)",
+    "version": "0.0.1"
+  },
+  "paths": {}
+}

--- a/tests/fixtures/compile-openapi-version/v300.yaml
+++ b/tests/fixtures/compile-openapi-version/v300.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.0
+info:
+  title: V300
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v301.yaml
+++ b/tests/fixtures/compile-openapi-version/v301.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.1
+info:
+  title: V301
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v302.yaml
+++ b/tests/fixtures/compile-openapi-version/v302.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.2
+info:
+  title: V302
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v303.yaml
+++ b/tests/fixtures/compile-openapi-version/v303.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.3
+info:
+  title: V303
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v304.yaml
+++ b/tests/fixtures/compile-openapi-version/v304.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.4
+info:
+  title: V304
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v310.yaml
+++ b/tests/fixtures/compile-openapi-version/v310.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.0
+info:
+  title: V310
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v311.yaml
+++ b/tests/fixtures/compile-openapi-version/v311.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.1
+info:
+  title: V311
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v312.yaml
+++ b/tests/fixtures/compile-openapi-version/v312.yaml
@@ -1,0 +1,5 @@
+openapi: 3.1.2
+info:
+  title: V312
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v32.yaml
+++ b/tests/fixtures/compile-openapi-version/v32.yaml
@@ -1,0 +1,5 @@
+openapi: 3.2.0
+info:
+  title: V32
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/v4.yaml
+++ b/tests/fixtures/compile-openapi-version/v4.yaml
@@ -1,0 +1,5 @@
+openapi: 4.0.0
+info:
+  title: V4
+  version: 0.0.1
+paths: {}

--- a/tests/fixtures/compile-openapi-version/zero-padded.yaml
+++ b/tests/fixtures/compile-openapi-version/zero-padded.yaml
@@ -1,0 +1,5 @@
+openapi: 3.0.01
+info:
+  title: Zero-padded
+  version: 0.0.1
+paths: {}


### PR DESCRIPTION
Closes #107.

Staged per VSDD §II:
1. **Tests-only commit** (be12949) — 23 tests + 18 fixtures asserting the `Preflight.check` contract. The Red-conditions gate cleared on this SHA — see the `✓ VSDD Red gate cleared at be12949...` marker comment posted by github-actions[bot].
2. **Implementation + follow-up fixes** (descend from the cleared SHA) — `src/compile/preflight.ts` turning the Red signal green, plus iterations addressing Phase 3 review feedback (JSON regex anchor preserved, BOM-strip helper removed since `TextDecoder` does it natively, fetch-body cancellation in `try/finally` to avoid leaks on read errors, `extract` exported for direct unit testing).

The Non-test-commit ancestry enforcement gate verifies that every non-test commit on this PR descends from the cleared marker SHA.

## Verification
`deno task test` — **24 passed | 0 failed | 1 ignored** (the ignored test is the hey-api wrap test, deferred per the spec until the compile-pipeline integration harness lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)