### PR TITLE
tests + impl(#241): RefSafety pre-flight ($ref escape detection)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,8 +3,8 @@
   "version": "0.0.0",
   "exports": "./src/mod.ts",
   "tasks": {
-    "test": "deno test --allow-read",
-    "test:coverage": "deno test --allow-read --coverage=coverage && deno coverage coverage",
+    "test": "deno test --allow-read --allow-write",
+    "test:coverage": "deno test --allow-read --allow-write --coverage=coverage && deno coverage coverage",
     "fmt": "deno fmt",
     "fmt:check": "deno fmt --check",
     "lint": "deno lint",

--- a/src/compile/ref-safety.ts
+++ b/src/compile/ref-safety.ts
@@ -1,0 +1,97 @@
+/**
+ * `$ref` pre-flight (closes #241 items 9-11).
+ *
+ * Walks every string-valued `$ref` in a spec document and refuses any
+ * external reference that resolves outside the allowed root. Hash-only
+ * refs (`#/components/...`) are local to the document and always
+ * allowed.
+ *
+ * Default allowed root: the spec file's directory. Pass
+ * `{ allowRefRoot: <dir> }` to broaden — useful when the spec lives in
+ * one repo subtree and shared types live in a sibling directory.
+ *
+ * The pre-flight uses `Deno.realPath` so symlinks can't smuggle a ref
+ * past the boundary check.
+ *
+ * @module
+ */
+
+import * as Yaml from "@std/yaml";
+import { dirname, isAbsolute, resolve } from "@std/path";
+
+export class RefEscapesRoot extends Error {
+  ref: string;
+  root: string;
+  constructor(context: string, opts: { ref: string; root: string }) {
+    super(
+      `${context} ($ref=${JSON.stringify(opts.ref)}, allowed root=${JSON.stringify(opts.root)})`,
+    );
+    this.name = "RefEscapesRoot";
+    this.ref = opts.ref;
+    this.root = opts.root;
+  }
+}
+
+export type CheckOptions = {
+  /** Override the default allowed root (the spec file's directory). */
+  allowRefRoot?: string;
+};
+
+/** Recursively collect every string `$ref` value from a parsed doc. */
+function collect(node: unknown, out: string[]): void {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const item of node) collect(item, out);
+    return;
+  }
+  const obj = node as Record<string, unknown>;
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === "$ref" && typeof value === "string") {
+      out.push(value);
+      continue;
+    }
+    collect(value, out);
+  }
+}
+
+/** Resolve a directory to its canonical, symlink-free form. */
+async function canonical(path: string): Promise<string> {
+  try {
+    return await Deno.realPath(path);
+  } catch {
+    // Path may not exist yet (broken ref, deliberately bad fixture). Fall
+    // back to lexical normalization — `resolve` is enough for the boundary
+    // check since we only need to compare prefixes against `root`.
+    return resolve(path);
+  }
+}
+
+/**
+ * Check that every external `$ref` in `specPath` resolves within the
+ * allowed root. Throws `RefEscapesRoot` on the first violation, naming
+ * the offending pointer.
+ */
+export async function checkRefSafety(specPath: string, opts: CheckOptions = {}): Promise<void> {
+  const text = await Deno.readTextFile(specPath);
+  const doc = Yaml.parse(text);
+
+  const refs: string[] = [];
+  collect(doc, refs);
+
+  const specDir = dirname(specPath);
+  const rootRaw = opts.allowRefRoot ?? specDir;
+  const root = await canonical(rootRaw);
+
+  for (const ref of refs) {
+    if (ref.startsWith("#")) continue; // local pointer, always allowed
+    const fileSegment = ref.split("#", 1)[0];
+    const target = isAbsolute(fileSegment) ? fileSegment : resolve(specDir, fileSegment);
+    const resolved = await canonical(target);
+    if (resolved !== root && !resolved.startsWith(root + "/")) {
+      throw new RefEscapesRoot(
+        `$ref escapes the allowed root`,
+        { ref, root },
+      );
+    }
+  }
+}

--- a/tests/compile/schema-ref_test.ts
+++ b/tests/compile/schema-ref_test.ts
@@ -1,0 +1,173 @@
+/**
+ * Red-Gate tests for `Compile.RefEscapesRoot` pre-flight (clesty issue #241).
+ *
+ * Per VSDD Phase 2a (Red Gate): these tests are written BEFORE the
+ * implementation exists. They MUST fail until the `src/compile/ref-safety.ts`
+ * module ships. The dynamic import is wrapped in a try/catch so the file
+ * still type-checks and runs — each test then throws a clear "not implemented"
+ * error so the Red Gate failure is unambiguous in the test output.
+ *
+ * Scope (test plan items 9, 10, 11):
+ *   9.  Path-traversal via `../` parent segments → `Compile.RefEscapesRoot`.
+ *   10. Absolute filesystem path (`/etc/passwd`) → `Compile.RefEscapesRoot`.
+ *   11. With `--allow-ref-root <dir>` (or programmatic equivalent), refs into
+ *       that broadened root succeed.
+ *
+ * The pre-flight runs against the spec's directory. It scans every string-
+ * valued `$ref` in the document, normalises the file portion, and rejects
+ * anything that resolves outside the allowed root. Hash-only refs
+ * (`#/components/...`) are local to the document and always allowed.
+ */
+
+import { assert, assertEquals, assertThrows } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const FIXTURE_DIR = fromFileUrl(new URL("../fixtures/schema-ref/", import.meta.url));
+
+// deno-lint-ignore no-explicit-any
+let RefSafety: any;
+try {
+  RefSafety = await import("../../src/compile/ref-safety.ts");
+} catch {
+  RefSafety = null;
+}
+
+function requireModule(): void {
+  if (!RefSafety) {
+    throw new Error(
+      "src/compile/ref-safety.ts not implemented yet — Red Gate (issue #241)",
+    );
+  }
+}
+
+Deno.test("ref pre-flight (item 9): rejects parent escape via '../'", async () => {
+  requireModule();
+  const specPath = join(FIXTURE_DIR, "parent-escape.yaml");
+  // The pre-flight is async because it may resolve symlinks via Deno.realPath.
+  let thrown: unknown;
+  try {
+    await RefSafety.checkRefSafety(specPath);
+  } catch (e) {
+    thrown = e;
+  }
+  assert(thrown !== undefined, "expected RefEscapesRoot to throw");
+  assertEquals(
+    (thrown as { name?: string }).name ??
+      (thrown as { constructor: { name: string } }).constructor.name,
+    "RefEscapesRoot",
+    "error class name must be Compile.RefEscapesRoot",
+  );
+  // Error message should name the offending pointer so the user can find it.
+  const msg = String((thrown as Error).message ?? "");
+  assert(msg.includes("../"), `error message should include offending ref: ${msg}`);
+});
+
+Deno.test("ref pre-flight (item 10): rejects absolute filesystem path", async () => {
+  requireModule();
+  const specPath = join(FIXTURE_DIR, "absolute-path.yaml");
+  let thrown: unknown;
+  try {
+    await RefSafety.checkRefSafety(specPath);
+  } catch (e) {
+    thrown = e;
+  }
+  assert(thrown !== undefined, "expected RefEscapesRoot to throw");
+  assertEquals(
+    (thrown as { name?: string }).name ??
+      (thrown as { constructor: { name: string } }).constructor.name,
+    "RefEscapesRoot",
+    "error class name must be Compile.RefEscapesRoot",
+  );
+  const msg = String((thrown as Error).message ?? "");
+  assert(msg.includes("/etc/passwd"), `error message should include offending ref: ${msg}`);
+});
+
+Deno.test("ref pre-flight (item 11): --allow-ref-root broadens the allowed root", async () => {
+  requireModule();
+  // Build a temp layout:
+  //   <tmp>/spec/api.yaml         — references ../shared/types.yaml#/components/schemas/Pet
+  //   <tmp>/shared/types.yaml     — defines Pet
+  // Default root (spec dir) would reject. With allowRefRoot=<tmp>, accept.
+  const tmp = await Deno.makeTempDir({ prefix: "clesty-ref-safety-" });
+  try {
+    const specDir = join(tmp, "spec");
+    const sharedDir = join(tmp, "shared");
+    await Deno.mkdir(specDir);
+    await Deno.mkdir(sharedDir);
+    const specPath = join(specDir, "api.yaml");
+    await Deno.writeTextFile(
+      specPath,
+      [
+        "openapi: 3.0.3",
+        "info:",
+        "  title: allow-ref-root probe",
+        "  version: 0.0.1",
+        "paths:",
+        "  /pets:",
+        "    get:",
+        "      operationId: getPet",
+        "      responses:",
+        '        "200":',
+        "          description: Pet via shared types",
+        "          content:",
+        "            application/json:",
+        "              schema:",
+        '                $ref: "../shared/types.yaml#/components/schemas/Pet"',
+        "components: {}",
+        "",
+      ].join("\n"),
+    );
+    await Deno.writeTextFile(
+      join(sharedDir, "types.yaml"),
+      [
+        "components:",
+        "  schemas:",
+        "    Pet:",
+        "      type: object",
+        "      required: [id]",
+        "      properties:",
+        "        id: { type: string }",
+        "",
+      ].join("\n"),
+    );
+
+    // Without broadened root: must reject (escapes specDir).
+    let rejected: unknown;
+    try {
+      await RefSafety.checkRefSafety(specPath);
+    } catch (e) {
+      rejected = e;
+    }
+    assert(rejected !== undefined, "default root must reject ../shared/types.yaml");
+
+    // With --allow-ref-root <tmp>: must accept (resolves within tmp).
+    await RefSafety.checkRefSafety(specPath, { allowRefRoot: tmp });
+  } finally {
+    await Deno.remove(tmp, { recursive: true });
+  }
+});
+
+Deno.test("ref pre-flight: allows hash-only local refs (smoke)", async () => {
+  requireModule();
+  const specPath = join(FIXTURE_DIR, "local-ref.yaml");
+  // Should resolve cleanly — no external file segment, no path traversal.
+  await RefSafety.checkRefSafety(specPath);
+});
+
+Deno.test("ref pre-flight: surfaces a usable error class shape", () => {
+  requireModule();
+  // The implementation must export a `RefEscapesRoot` error class with the
+  // matching `name` so callers can `instanceof`-check or pattern-match it.
+  assert(typeof RefSafety.RefEscapesRoot === "function", "RefEscapesRoot must be exported");
+  const err = new RefSafety.RefEscapesRoot("probe", { ref: "../x", root: "/tmp/spec" });
+  assertEquals(err.name, "RefEscapesRoot");
+  // The constructor signature is part of the contract — second arg carries
+  // the ref + root context. If this assertion fails, callers can't surface
+  // the offending pointer in error messages.
+  assertThrows(
+    () => {
+      throw err;
+    },
+    RefSafety.RefEscapesRoot,
+  );
+});

--- a/tests/fixtures/schema-ref/30-sibling.yaml
+++ b/tests/fixtures/schema-ref/30-sibling.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — 3.0 sibling
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: getPet
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+                description: This sibling MUST be silently ignored on 3.0.
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/tests/fixtures/schema-ref/31-sibling.yaml
+++ b/tests/fixtures/schema-ref/31-sibling.yaml
@@ -1,0 +1,27 @@
+openapi: 3.1.0
+info:
+  title: Schema $ref — 3.1 sibling
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: getPet
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+                description: This sibling MUST surface on 3.1 as a doc comment.
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/tests/fixtures/schema-ref/absolute-path.yaml
+++ b/tests/fixtures/schema-ref/absolute-path.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — absolute path (refusal case)
+  version: 0.0.1
+paths:
+  /pwn:
+    get:
+      operationId: getPwnAbs
+      responses:
+        "200":
+          description: Absolute filesystem path — clesty pre-flight rejects
+          content:
+            application/json:
+              schema:
+                $ref: "/etc/passwd"
+components: {}

--- a/tests/fixtures/schema-ref/chain.yaml
+++ b/tests/fixtures/schema-ref/chain.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — chain ($ref -> $ref)
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: getPet
+      responses:
+        "200":
+          description: A pet via a ref-chain
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PetAlias"
+components:
+  schemas:
+    PetAlias:
+      $ref: "#/components/schemas/Pet"
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/tests/fixtures/schema-ref/external-file/components.yaml
+++ b/tests/fixtures/schema-ref/external-file/components.yaml
@@ -1,0 +1,11 @@
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/tests/fixtures/schema-ref/external-file/main.yaml
+++ b/tests/fixtures/schema-ref/external-file/main.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — external file
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: getPet
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: "./components.yaml#/components/schemas/Pet"
+components: {}

--- a/tests/fixtures/schema-ref/local-ref.yaml
+++ b/tests/fixtures/schema-ref/local-ref.yaml
@@ -1,0 +1,26 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — local
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: getPet
+      responses:
+        "200":
+          description: A pet
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id, name]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string

--- a/tests/fixtures/schema-ref/missing-target.yaml
+++ b/tests/fixtures/schema-ref/missing-target.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — missing target (refusal case)
+  version: 0.0.1
+paths:
+  /missing:
+    get:
+      operationId: getMissing
+      responses:
+        "200":
+          description: Pointer names a schema that does not exist
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DoesNotExist"
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string

--- a/tests/fixtures/schema-ref/non-string-ref.yaml
+++ b/tests/fixtures/schema-ref/non-string-ref.yaml
@@ -1,0 +1,23 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — non-string (refusal case)
+  version: 0.0.1
+paths:
+  /broken:
+    get:
+      operationId: getBroken
+      responses:
+        "200":
+          description: $ref must be a string per spec; this MUST be rejected
+          content:
+            application/json:
+              schema:
+                $ref: 42
+components:
+  schemas:
+    Pet:
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string

--- a/tests/fixtures/schema-ref/parent-escape.yaml
+++ b/tests/fixtures/schema-ref/parent-escape.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — parent escape (refusal case)
+  version: 0.0.1
+paths:
+  /pwn:
+    get:
+      operationId: getPwn
+      responses:
+        "200":
+          description: Path-traversal via parent segments — clesty pre-flight rejects
+          content:
+            application/json:
+              schema:
+                $ref: "../../etc/passwd"
+components: {}

--- a/tests/fixtures/schema-ref/pointer-escape.yaml
+++ b/tests/fixtures/schema-ref/pointer-escape.yaml
@@ -1,0 +1,29 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — JSON Pointer escapes
+  version: 0.0.1
+paths:
+  /weird:
+    get:
+      operationId: getWeird
+      responses:
+        "200":
+          description: A schema reached via ~0 (~) and ~1 (/) escapes
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/foo~1bar"
+components:
+  schemas:
+    "foo/bar":
+      type: object
+      required: [id]
+      properties:
+        id:
+          type: string
+    "tilde~name":
+      type: object
+      required: [v]
+      properties:
+        v:
+          type: string

--- a/tests/fixtures/schema-ref/recursive.yaml
+++ b/tests/fixtures/schema-ref/recursive.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Schema $ref — recursive
+  version: 0.0.1
+paths:
+  /tree:
+    get:
+      operationId: getTree
+      responses:
+        "200":
+          description: A tree node (self-referential)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Tree"
+components:
+  schemas:
+    Tree:
+      type: object
+      required: [value]
+      properties:
+        value:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tree"

--- a/tests/integration/schema-ref_test.ts
+++ b/tests/integration/schema-ref_test.ts
@@ -1,0 +1,331 @@
+/**
+ * Red-Gate integration tests for hey-api's Schema `$ref` behaviour
+ * (clesty issue #241, test plan items 1–8).
+ *
+ * Every test in this file is `Deno.test.ignore`. The clesty compile pipeline
+ * (programmatic API + generated-TS assertion harness) does not exist yet.
+ * Test bodies are fully written so that, the moment the harness lands, the
+ * suite runs as-is. Each `.ignore` carries a `TODO(#241)` comment explaining
+ * what needs to exist before the test can be unskipped.
+ *
+ * Spec mapping:
+ *   1. Local `$ref` resolves end-to-end.
+ *   2. 3.0 sibling silently ignored (compile MUST succeed; sibling does NOT
+ *      surface as a doc comment).
+ *   3. 3.1 sibling annotation surfaces (sibling description appears in
+ *      generated TS as a field-level doc comment, while the resolved type
+ *      still reflects the target).
+ *   4. External-file ref (inside spec dir) resolves.
+ *   5. JSON Pointer escape (`~1` → `/`) resolves.
+ *   6. `$ref` chain (`$ref` → `$ref`) resolves.
+ *   7. Refusal cases: non-string ref, missing target, parent escape,
+ *      absolute path — each must yield a `Compile.*` error with origin.
+ *   8. Recursive type (Tree → Tree) — the highest-risk hey-api canary.
+ *      Must produce a self-referential TS type alias, not a stack overflow.
+ */
+
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
+
+const FIXTURE_DIR = fromFileUrl(new URL("../fixtures/schema-ref/", import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Compile-pipeline shim
+// ---------------------------------------------------------------------------
+// These types describe the programmatic API the integration tests will call
+// once the harness lands. The actual implementation will live under
+// `src/compile/` and re-export hey-api's generator with clesty's pre-flight
+// + error wrapping. The types here document the contract the tests need.
+// ---------------------------------------------------------------------------
+
+interface CompileResult {
+  /** Map of generated filename → file contents. Used to assert on emitted TS. */
+  files: Record<string, string>;
+}
+
+interface CompileOptions {
+  allowRefRoot?: string;
+}
+
+function compile(_specPath: string, _opts?: CompileOptions): Promise<CompileResult> {
+  // Placeholder — replaced by real implementation in the Green Gate row.
+  // Intentionally throws so anyone who unskips a test before the harness
+  // lands gets a clear signal. Returns a Promise to match the eventual
+  // async API shape so call sites don't have to change when wired up.
+  return Promise.reject(
+    new Error("clesty compile pipeline not implemented yet (issue #241)"),
+  );
+}
+
+/** Concatenate every emitted TS file — most assertions only care about content. */
+function emittedSource(result: CompileResult): string {
+  return Object.entries(result.files)
+    .filter(([name]) => name.endsWith(".ts"))
+    .map(([, body]) => body)
+    .join("\n\n// ---- file boundary ----\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Item 1: Local $ref resolves
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 1): local $ref resolves to target schema",
+  // TODO(#241): unskip once src/compile/{pipeline,api}.ts is wired up.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "local-ref.yaml"));
+    const src = emittedSource(result);
+    // hey-api emits a `Pet` type with the target's structure.
+    assertStringIncludes(src, "Pet");
+    assertStringIncludes(src, "name");
+    assertStringIncludes(src, "id");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 2: 3.0 sibling silently ignored
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 2): 3.0 doc with $ref + description sibling — sibling silently dropped",
+  // TODO(#241): needs compile pipeline + generated-TS scanning.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "30-sibling.yaml"));
+    const src = emittedSource(result);
+    // Compile must succeed; the resolved type must still be Pet's shape.
+    assertStringIncludes(src, "Pet");
+    assertStringIncludes(src, "name");
+    // Spec rule: 3.0 ignores siblings silently. The sibling description
+    // text must NOT appear in generated output (it's not annotated, not
+    // attached as a doc comment, just dropped).
+    assert(
+      !src.includes("This sibling MUST be silently ignored on 3.0."),
+      "3.0 sibling description leaked into generated TS — spec violation",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 3: 3.1 sibling annotation surfaces
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 3): 3.1 doc with $ref + description sibling — sibling surfaces as doc comment",
+  // TODO(#241): needs compile pipeline + JSDoc-aware generated-TS scanning.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "31-sibling.yaml"));
+    const src = emittedSource(result);
+    // Resolved type still reflects Pet.
+    assertStringIncludes(src, "Pet");
+    assertStringIncludes(src, "name");
+    // Sibling description must appear somewhere in the generated TS — most
+    // likely as a JSDoc `*` comment on the field. We assert on substring
+    // rather than exact JSDoc shape because hey-api's emit format is its
+    // own concern; if hey-api changes JSDoc style, this test stays useful.
+    assertStringIncludes(src, "This sibling MUST surface on 3.1 as a doc comment.");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 4: External-file ref (inside spec dir)
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 4): external-file $ref inside spec dir resolves",
+  // TODO(#241): needs compile pipeline; no networking required for this fixture.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "external-file/main.yaml"));
+    const src = emittedSource(result);
+    assertStringIncludes(src, "Pet");
+    assertStringIncludes(src, "name");
+    assertStringIncludes(src, "id");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 5: JSON Pointer escape — `~1` → `/`
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 5): JSON Pointer escape ~1 resolves to component named foo/bar",
+  // TODO(#241): needs compile pipeline + generated-TS scanning.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "pointer-escape.yaml"));
+    const src = emittedSource(result);
+    // Hey-api will sanitize `foo/bar` into a TS-safe identifier (e.g.
+    // `FooBar`). We don't pin the exact transform — we assert that the
+    // unique field `id: string` from the target schema landed in the output
+    // and that no "unresolved" ref string survived.
+    assertStringIncludes(src, "id");
+    assert(!src.includes("foo~1bar"), "pointer escape leaked unresolved into TS");
+    assert(!src.includes("$ref"), "$ref string leaked unresolved into TS");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 6: $ref chain ($ref -> $ref)
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 6): chain ($ref -> $ref) resolves to terminal target",
+  // TODO(#241): needs compile pipeline.
+  async () => {
+    const result = await compile(join(FIXTURE_DIR, "chain.yaml"));
+    const src = emittedSource(result);
+    assertStringIncludes(src, "Pet");
+    assertStringIncludes(src, "name");
+    assertStringIncludes(src, "id");
+    assert(!src.includes("$ref"), "$ref string leaked unresolved into TS");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 7: Refusal cases — each must yield a Compile.* error with origin
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 7a): non-string $ref → Compile.HeyApiFailure",
+  // TODO(#241): needs compile pipeline + error class hierarchy.
+  async () => {
+    const specPath = join(FIXTURE_DIR, "non-string-ref.yaml");
+    let thrown: unknown;
+    try {
+      await compile(specPath);
+    } catch (e) {
+      thrown = e;
+    }
+    assert(thrown !== undefined, "expected compile to throw");
+    const name = (thrown as { name?: string }).name;
+    assertEquals(name, "HeyApiFailure", "must wrap hey-api's error as Compile.HeyApiFailure");
+    // Origin (source path) must be present in the error chain so users can
+    // locate the offending document.
+    const msg = String((thrown as Error).message ?? "");
+    assertStringIncludes(msg, "non-string-ref.yaml");
+  },
+);
+
+Deno.test.ignore(
+  "integration (item 7b): missing-target $ref → Compile.HeyApiFailure with pointer",
+  // TODO(#241): needs compile pipeline + error class hierarchy.
+  async () => {
+    const specPath = join(FIXTURE_DIR, "missing-target.yaml");
+    let thrown: unknown;
+    try {
+      await compile(specPath);
+    } catch (e) {
+      thrown = e;
+    }
+    assert(thrown !== undefined, "expected compile to throw");
+    const name = (thrown as { name?: string }).name;
+    assertEquals(name, "HeyApiFailure", "must wrap hey-api's error as Compile.HeyApiFailure");
+    const msg = String((thrown as Error).message ?? "");
+    // Error must name the missing pointer so the user can find it.
+    assertStringIncludes(msg, "DoesNotExist");
+  },
+);
+
+Deno.test.ignore(
+  "integration (item 7c): parent-escape $ref → Compile.RefEscapesRoot (pre-flight)",
+  // TODO(#241): needs compile pipeline + RefEscapesRoot integration.
+  async () => {
+    const specPath = join(FIXTURE_DIR, "parent-escape.yaml");
+    let thrown: unknown;
+    try {
+      await compile(specPath);
+    } catch (e) {
+      thrown = e;
+    }
+    assert(thrown !== undefined, "expected compile to throw");
+    const name = (thrown as { name?: string }).name;
+    assertEquals(
+      name,
+      "RefEscapesRoot",
+      "parent escape must be caught by clesty pre-flight, NOT hey-api",
+    );
+  },
+);
+
+Deno.test.ignore(
+  "integration (item 7d): absolute-path $ref → Compile.RefEscapesRoot (pre-flight)",
+  // TODO(#241): needs compile pipeline + RefEscapesRoot integration.
+  async () => {
+    const specPath = join(FIXTURE_DIR, "absolute-path.yaml");
+    let thrown: unknown;
+    try {
+      await compile(specPath);
+    } catch (e) {
+      thrown = e;
+    }
+    assert(thrown !== undefined, "expected compile to throw");
+    const name = (thrown as { name?: string }).name;
+    assertEquals(
+      name,
+      "RefEscapesRoot",
+      "absolute path must be caught by clesty pre-flight, NOT hey-api",
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item 8: RECURSIVE TYPE — highest-risk hey-api canary
+// ---------------------------------------------------------------------------
+// Per spec: "@hey-api/json-schema-ref-parser defaults *can* throw `Maximum
+// call stack size exceeded` on cycles unless configured to bundle/dereference
+// lazily. If hey-api regresses here, this test fails immediately."
+//
+// The body below is fully written. If a hey-api update reintroduces a cycle
+// regression, unskipping this test alone is enough to detect it.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "integration (item 8, CRITICAL CANARY): recursive Tree -> Tree compiles to self-referential type",
+  // TODO(#241): unskip the moment the compile harness lands. This is the
+  // highest-priority canary in the row — DO NOT delete or weaken its body.
+  async () => {
+    const specPath = join(FIXTURE_DIR, "recursive.yaml");
+
+    // 1. Compile must complete. A regression to the "stack overflow on
+    //    cycles" failure mode would throw here. The .catch+rethrow-with-
+    //    context pattern makes the failure mode obvious in test output.
+    let result: CompileResult;
+    try {
+      result = await compile(specPath);
+    } catch (e) {
+      throw new Error(
+        `RECURSIVE-TYPE CANARY FAILED — hey-api regression suspected. ` +
+          `Original error: ${(e as Error).message ?? e}`,
+      );
+    }
+
+    const src = emittedSource(result);
+
+    // 2. The generated TS must mention `Tree`. We don't pin the exact emit
+    //    shape (interface vs type alias, optional vs required `children`)
+    //    because hey-api's output style is its own concern. The contract is:
+    //    the type exists and is self-referential.
+    assertStringIncludes(src, "Tree");
+
+    // 3. Self-reference: somewhere in the generated source, `Tree` must
+    //    appear in a context where the `Tree` type references itself
+    //    (typically through `children?: Array<Tree>` or `Tree[]`). We assert
+    //    on the loose substring patterns hey-api is known to emit; if it
+    //    changes its style, the test surfaces a false positive that the
+    //    Green-Gate row owner can update — which is preferable to silently
+    //    accepting a flattened (non-recursive) emit.
+    const selfRefPatterns = [
+      /Tree\s*\[\]/, //                     Tree[]
+      /Array<\s*Tree\s*>/, //               Array<Tree>
+      /children\??\s*:\s*Tree/, //          children: Tree...
+    ];
+    const matched = selfRefPatterns.some((re) => re.test(src));
+    assert(
+      matched,
+      "expected generated TS to contain a self-reference to Tree (Tree[], Array<Tree>, or children: Tree...) — got:\n" +
+        src,
+    );
+
+    // 4. No raw `$ref` strings should leak — that would mean hey-api gave up
+    //    on cycle resolution.
+    assert(!src.includes("$ref"), "$ref string leaked unresolved into TS");
+  },
+);


### PR DESCRIPTION
Closes the pre-flight portion of #241 (items 9-11).

Staged per VSDD §II:
1. **Tests-only commit** (0129a13) — Red-Gate suite + 13 fixtures asserting `RefSafety.checkRefSafety` rejects parent-escape and absolute-path refs, accepts hash-only refs, and broadens via `--allow-ref-root`. Red-conditions gate cleared on this SHA per the `✓ VSDD Red gate cleared at 0129a13...` marker.
2. **Implementation commit** — `src/compile/ref-safety.ts` (RefEscapesRoot class + recursive `$ref` walker that uses `Deno.realPath` to defeat symlink-based bypasses) plus a `deno.json` `--allow-write` addition so the item-11 temp-dir test can run. The impl commit descends from the cleared marker — Non-test-blocker gate confirms.

Integration items remain `Deno.test.ignore`d pending the compile-and-run harness.

## Verification
`deno task test` — **83 passed | 0 failed | 41 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)