### PR TITLE
feat(vsdd): onboard sw2m/philosophies CI workflows as thin callers

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,17 +10,17 @@
 # (HTTP 422 otherwise). Keep each `description:` line ≤100 chars.
 
 - name: "spec:goal"
-  color: "0e8a16"  # green
+  color: "0e8a16" # green
   description: "Goal-spec issue. Many goals OK; no implementation detail. Assigning triggers goal→tech promotion."
 
 - name: "spec:tech"
-  color: "1d76db"  # blue
+  color: "1d76db" # blue
   description: "Tech-spec issue. One technical problem. Assigning triggers tech→PR 5-phase promotion pipeline."
 
 - name: "needs-human"
-  color: "fbca04"  # yellow
+  color: "fbca04" # yellow
   description: "Promotion pipeline bailed (Red gate or Green gate exhausted retries). Human intervention required."
 
 - name: "ci-meta"
-  color: "5319e7"  # purple
+  color: "5319e7" # purple
   description: "Issue opened by VSDD CI meta-review consensus. Tracks a CI gap against MEMORY.md."

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,26 @@
+# Labels managed by `.github/workflows/vsdd-labels.yml`. Re-run that
+# workflow manually (workflow_dispatch) after editing this file —
+# push-on-main triggers it automatically when this file changes.
+#
+# Mirrors sw2m/philosophies' label set so the VSDD workflows can
+# reference the same names (`spec:goal`, `spec:tech`, `needs-human`,
+# `ci-meta`) consistently across the org.
+#
+# GitHub label descriptions are capped at 100 characters by the API
+# (HTTP 422 otherwise). Keep each `description:` line ≤100 chars.
+
+- name: "spec:goal"
+  color: "0e8a16"  # green
+  description: "Goal-spec issue. Many goals OK; no implementation detail. Assigning triggers goal→tech promotion."
+
+- name: "spec:tech"
+  color: "1d76db"  # blue
+  description: "Tech-spec issue. One technical problem. Assigning triggers tech→PR 5-phase promotion pipeline."
+
+- name: "needs-human"
+  color: "fbca04"  # yellow
+  description: "Promotion pipeline bailed (Red gate or Green gate exhausted retries). Human intervention required."
+
+- name: "ci-meta"
+  color: "5319e7"  # purple
+  description: "Issue opened by VSDD CI meta-review consensus. Tracks a CI gap against MEMORY.md."

--- a/.github/workflows/vsdd-ci-meta.yml
+++ b/.github/workflows/vsdd-ci-meta.yml
@@ -1,0 +1,28 @@
+name: VSDD CI Meta-Review
+
+# Thin caller — delegates to sw2m/philosophies. Evaluates clesty's CI
+# workflows against the canonical VSDD doc (sw2m/philosophies' MEMORY.md
+# at main) using BOTH Gemini + Claude in parallel. Disagreement opens a
+# tracked goal-spec issue per gap and fails the consensus check.
+#
+# Fires on PRs that touch CI files. The `paths:` filter mirrors the
+# called workflow's intent — keep meta-review cheap by only firing when
+# CI surface area changes.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/ci-meta.yml@main
+    secrets: inherit

--- a/.github/workflows/vsdd-issues.yml
+++ b/.github/workflows/vsdd-issues.yml
@@ -1,0 +1,19 @@
+name: VSDD Issue Review (Phase 1c)
+
+# Thin caller — delegates to sw2m/philosophies. Adversarial spec review
+# (Gemini + Claude) on issue open/edit/assigned. Advisory only — never
+# gates. Org-membership and ownership-by-assignment are enforced inside
+# the called workflow.
+
+on:
+  issues:
+    types: [opened, edited, assigned]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/issue-review.yml@main
+    secrets: inherit

--- a/.github/workflows/vsdd-labels.yml
+++ b/.github/workflows/vsdd-labels.yml
@@ -1,0 +1,73 @@
+name: Sync VSDD labels
+
+# Idempotent label sync. Reads `.github/labels.yml` (a list of
+# {name, color, description}) and ensures each label exists with the
+# specified color/description. Safe to re-run.
+#
+# Pre-checks for >100-char descriptions before any API call (the
+# GitHub label-description limit) so a too-long entry fails fast with
+# a per-label list, rather than silently losing labels on HTTP 422.
+#
+# This workflow is local to clesty (not delegated) because GitHub
+# labels live per-repo. The .github/labels.yml content mirrors
+# sw2m/philosophies so the names stay consistent across the org.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/vsdd-labels.yml"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Sync labels via gh CLI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f .github/labels.yml ]; then
+            echo "::error::.github/labels.yml not found"
+            exit 1
+          fi
+          python3 - <<'PY'
+          import subprocess, sys, yaml
+          with open('.github/labels.yml') as f:
+              labels = yaml.safe_load(f)
+          if not isinstance(labels, list):
+              print('::error::.github/labels.yml must be a list of {name,color,description}', file=sys.stderr)
+              sys.exit(1)
+          oversize = [(e['name'], len(e.get('description', ''))) for e in labels
+                      if len(e.get('description', '')) > 100]
+          if oversize:
+              print('::error::Label description(s) exceed the GitHub 100-char limit:', file=sys.stderr)
+              for name, n in oversize:
+                  print(f'  {name}: {n} chars (max 100)', file=sys.stderr)
+              sys.exit(1)
+          failed = []
+          for entry in labels:
+              name = entry['name']
+              color = entry.get('color', 'cccccc').lstrip('#')
+              desc = entry.get('description', '')
+              cmd = ['gh', 'label', 'create', name, '--color', color, '--description', desc, '--force']
+              r = subprocess.run(cmd, capture_output=True, text=True)
+              status = 'ok' if r.returncode == 0 else f'FAIL ({r.returncode})'
+              print(f'  [{status}] {name}')
+              if r.returncode != 0:
+                  print(f'    stdout: {r.stdout}')
+                  print(f'    stderr: {r.stderr}')
+                  failed.append(name)
+          if failed:
+              print(f'::error::Label sync failed for: {", ".join(failed)}', file=sys.stderr)
+              sys.exit(1)
+          PY

--- a/.github/workflows/vsdd-non-test-blocker.yml
+++ b/.github/workflows/vsdd-non-test-blocker.yml
@@ -1,0 +1,19 @@
+name: VSDD Non-test-blocker (ancestry enforcement)
+
+# Thin caller — delegates to sw2m/philosophies. Walks every commit on
+# the PR; non-test commits must be descendants of the most recent
+# `github-actions[bot]` Red-gate-cleared marker. Pairs with
+# vsdd-red-conditions.yml.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/non-test-blocker.yml@main
+    secrets: inherit

--- a/.github/workflows/vsdd-promote.yml
+++ b/.github/workflows/vsdd-promote.yml
@@ -1,0 +1,24 @@
+name: VSDD Promotion Pipeline
+
+# Thin caller — delegates to sw2m/philosophies. Assignment-triggered
+# promotion of issues:
+#   - `spec:goal` + assignee org-member → goal decomposed into
+#     N tech-spec sub-issues (one technical problem per §VII).
+#   - `spec:tech` + assignee org-member → 5-phase tech→PR pipeline
+#     (scaffold → author tests → Red gate → implement → Green gate;
+#     retry caps 3, bail with `needs-human` label).
+
+on:
+  issues:
+    types: [assigned]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/promote.yml@main
+    secrets: inherit

--- a/.github/workflows/vsdd-pulls.yml
+++ b/.github/workflows/vsdd-pulls.yml
@@ -1,0 +1,21 @@
+name: VSDD Pull Request Review (Phase 3)
+
+# Thin caller — delegates to sw2m/philosophies. Two adversarial
+# reviewers (Gemini + Claude) on the PR diff for cognitive diversity
+# (MEMORY.md §V), §IX symbol audit, and ownership-gating per §I.
+# Advisory only — never gates merge by itself.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, assigned]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/pr-review.yml@main
+    secrets: inherit

--- a/.github/workflows/vsdd-red-conditions.yml
+++ b/.github/workflows/vsdd-red-conditions.yml
@@ -1,0 +1,21 @@
+name: VSDD Red-conditions Gate
+
+# Thin caller — delegates to sw2m/philosophies. §VIII Red Gate
+# enforcement for non-promote-pipeline PRs (#54). Three chained clauses
+# (test-commits-only, test-runner-red, coverage-adequate); on all-pass,
+# posts the `github-actions[bot]` marker comment that the
+# non-test-blocker CI uses as the cleared-from anchor.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  vsdd:
+    uses: sw2m/philosophies/.github/workflows/red-conditions-gate.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary

Onboards the sw2m/philosophies VSDD CI workflows to clesty as **thin callers** (\`uses: sw2m/philosophies/.github/workflows/<name>.yml@main\`). The existing \`ci.yml\` (Deno fmt/lint/typecheck/test) is unchanged — it remains the internal gate; VSDD workflows layer cognitive-diversity review, ownership-by-assignment HIL, and §VIII Red Gate enforcement on top.

This PR is **infrastructure-only** — no functional changes to clesty. After merge, opening an issue or PR routes through the same review/promotion pipeline that philosophies dogfoods.

## What's added

| File | Delegates to | Purpose |
|---|---|---|
| \`vsdd-issues.yml\` | \`issue-review.yml\` | Phase 1c spec review (Gemini+Claude) |
| \`vsdd-pulls.yml\` | \`pr-review.yml\` | Phase 3 adversarial review + §IX symbol audit |
| \`vsdd-ci-meta.yml\` | \`ci-meta.yml\` | CI eval against canonical VSDD doc |
| \`vsdd-promote.yml\` | \`promote.yml\` | Assignment-triggered goal→tech→PR pipeline |
| \`vsdd-red-conditions.yml\` | \`red-conditions-gate.yml\` | §VIII Red Gate (3-clause) |
| \`vsdd-non-test-blocker.yml\` | \`non-test-blocker.yml\` | Ancestry enforcement against marker |
| \`vsdd-labels.yml\` (local) | — | Idempotent label sync from \`.github/labels.yml\` |
| \`.github/labels.yml\` | — | \`spec:goal\`, \`spec:tech\`, \`needs-human\`, \`ci-meta\` |

clesty is a code repo (Deno-based, has \`deno.json\`), so \`repo-shape\` detects \`has-tests=true\` and §VIII actually enforces here (vs philosophies' docs-repo N/A carve-out).

## Not onboarded (deliberate)

- **\`test.yml\`** — its \`structural-sanity\` job greps MEMORY.md for nine Roman-numeral sections, which is philosophies-specific. The other jobs (markdown-lint, lychee, issue-linkage, green-gate) are reusable but \`test.yml\` ships them as a single unit. Pending a philosophies refactor that splits reusable-from-repo-specific. Will file as a follow-up if useful.

## Pre-merge checklist (admin tasks)

- [ ] Set repo secrets: \`GEMINI_API_KEY\`, \`ANTHROPIC_API_KEY\`
- [ ] (Optional) Set repo var \`VSDD_TEST_GLOBS\` — defaults already cover \`tests/**\`, \`**/*_test.*\`, \`**/*.test.*\`, \`**/*.spec.*\` which match clesty's \`tests/\` directory.
- [ ] Confirm anonhostpi (and any other intended owners) have **public** sw2m org membership — workflows hard-fail on non-public for the default GITHUB_TOKEN.
- [ ] Depends on sw2m/philosophies#74 (adds \`workflow_call:\` to red-gate workflows). Wait for #74 to land before merging this PR or the two red-gate callers will resolve as unreferable.

## Post-merge

- Add new required checks to clesty's branch-protection ruleset on \`main\`:
  - \`Verify org-member ownership\`
  - \`Consensus + open issues for gaps\`
  - \`Gemini VSDD CI evaluation\`, \`Claude VSDD CI evaluation\`
  - \`Gemini adversarial review\`, \`Claude adversarial review\` (advisory; can be soft)
  - \`Red-conditions gate (3-clause)\`
  - \`Non-test-commit ancestry enforcement\`

## Test plan

- [ ] CI passes on this PR (Deno ci.yml still gates fmt/lint/typecheck/test).
- [ ] After merge, the next push to \`main\` triggers \`vsdd-labels\` and the four labels appear via \`gh label list\`.
- [ ] Open a fresh issue post-merge → \`vsdd-issues.yml\` fires; both Gemini and Claude post Phase 1c review comments after an org member self-assigns.
- [ ] Open a fresh PR post-merge → \`vsdd-pulls.yml\` fires; both adversarial reviews post; \`vsdd-ci-meta.yml\` fires only if CI files change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)