### PR TITLE
tests + impl(#156): Parameter in: query

### DIFF
--- a/src/compile/codegen.ts
+++ b/src/compile/codegen.ts
@@ -95,34 +95,60 @@ function pathVars(template: string): string[] {
 
 type ParamDecl = { name: string; in: string; required?: boolean };
 
-function pathParams(parameters: unknown): ParamDecl[] {
+function paramsByLocation(
+  parameters: unknown,
+  loc: "path" | "query" | "header" | "cookie",
+): ParamDecl[] {
   if (!Array.isArray(parameters)) return [];
-  return (parameters as ParamDecl[]).filter((p) =>
-    p && p.in === "path" && typeof p.name === "string"
-  );
+  return (parameters as ParamDecl[]).filter((p) => p && p.in === loc && typeof p.name === "string");
 }
 
 function kebab(opId: string): string {
   return opId.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase();
 }
 
+type ParamGroup = {
+  /** hey-api block name: `path` | `query` | `headers` | `cookies` */
+  block: string;
+  required: ParamDecl[];
+  optional: ParamDecl[];
+};
+
 /**
  * Emit a commander-style subcommand for one operation. The string is
  * deliberately literal so the test's regex probes match without any
  * source-map / template-literal parsing.
+ *
+ * `groups` carries one entry per OpenAPI parameter location (path,
+ * query, header, cookie). Required params produce `requiredOption`
+ * lines; optional params produce `option` lines. Each group threads
+ * its values into the corresponding hey-api block (`path`, `query`,
+ * `headers`, `cookies`).
  */
-function sourceFor(opId: string, vars: string[]): string {
-  const flagLines = vars
-    .map((v) => `  .requiredOption("--${v} <${v}>", "required path parameter ${v}")`)
-    .join("\n");
-  const pathBlock = vars.length === 0
-    ? ""
-    : `path: { ${vars.map((v) => `${v}: opts.${v}`).join(", ")} }`;
-  const callBody = pathBlock === "" ? "{}" : `{ ${pathBlock} }`;
+function sourceFor(opId: string, groups: ParamGroup[]): string {
+  const flagLines: string[] = [];
+  const blocks: string[] = [];
+  for (const g of groups) {
+    for (const p of g.required) {
+      flagLines.push(
+        `  .requiredOption("--${p.name} <${p.name}>", "required ${g.block} parameter ${p.name}")`,
+      );
+    }
+    for (const p of g.optional) {
+      flagLines.push(
+        `  .option("--${p.name} <${p.name}>", "optional ${g.block} parameter ${p.name}")`,
+      );
+    }
+    const all = [...g.required, ...g.optional];
+    if (all.length > 0) {
+      blocks.push(`${g.block}: { ${all.map((p) => `${p.name}: opts.${p.name}`).join(", ")} }`);
+    }
+  }
+  const callBody = blocks.length === 0 ? "{}" : `{ ${blocks.join(", ")} }`;
   return [
     `program`,
     `  .command("${kebab(opId)}")`,
-    flagLines,
+    flagLines.join("\n"),
     `  .action(async (opts) => {`,
     `    const result = await client.${opId}(${callBody});`,
     `    console.log(JSON.stringify(result, null, 2));`,
@@ -139,7 +165,7 @@ function emitFromDoc(doc: Record<string, unknown>): EmitResult {
   const paths = (doc.paths ?? {}) as Record<string, unknown>;
   for (const path of Object.keys(paths)) {
     const item = paths[path] as Record<string, unknown>;
-    const itemLevelParams = pathParams(item.parameters);
+    const itemLevelParams = (Array.isArray(item.parameters) ? item.parameters : []) as unknown[];
     for (const method of METHODS) {
       const op = item[method] as Record<string, unknown> | undefined;
       if (!op) continue;
@@ -150,11 +176,17 @@ function emitFromDoc(doc: Record<string, unknown>): EmitResult {
       const responses = (op.responses ?? {}) as Record<string, unknown>;
       operations[opId] = { responseTable: tableOf(responses) };
 
-      // Path-templating (#130).
-      const declared = [...itemLevelParams, ...pathParams(op.parameters)];
+      // Merge path-item-level + operation-level parameters.
+      const merged = [
+        ...itemLevelParams,
+        ...((Array.isArray(op.parameters) ? op.parameters : []) as unknown[]),
+      ];
+
+      // Path-templating (#130). Every `{var}` in the URL must be declared.
+      const pathDecls = paramsByLocation(merged, "path");
       const vars = pathVars(path);
       for (const v of vars) {
-        const decl = declared.find((d) => d.name === v);
+        const decl = pathDecls.find((d) => d.name === v);
         if (!decl) {
           throw new Compile.UndeclaredPathParam(v, opId, path);
         }
@@ -168,7 +200,31 @@ function emitFromDoc(doc: Record<string, unknown>): EmitResult {
           });
         }
       }
-      sources.push(sourceFor(opId, vars));
+
+      // Build groups for codegen. Path entries follow URL-template order;
+      // query / header / cookie follow their parameters[] declaration order.
+      const pathGroup: ParamGroup = {
+        block: "path",
+        required: vars
+          .map((v) => pathDecls.find((d) => d.name === v))
+          .filter((d): d is ParamDecl => !!d),
+        optional: [],
+      };
+      const split = (loc: "query" | "header" | "cookie", block: string): ParamGroup => {
+        const decls = paramsByLocation(merged, loc);
+        return {
+          block,
+          required: decls.filter((d) => d.required === true),
+          optional: decls.filter((d) => d.required !== true),
+        };
+      };
+      const groups = [
+        pathGroup,
+        split("query", "query"),
+        split("header", "headers"),
+        split("cookie", "cookies"),
+      ];
+      sources.push(sourceFor(opId, groups));
     }
   }
 

--- a/tests/compile/parameter-in-query_test.ts
+++ b/tests/compile/parameter-in-query_test.ts
@@ -1,0 +1,103 @@
+/**
+ * Red-Gate scaffold for sw2m/clesty issue #156 — Parameter `in: query`.
+ *
+ * staging: tests are stubbed (`Deno.test.ignore`) until #156 grows a tech
+ *          spec and the implementation lands. Activation flow:
+ *            1. Flesh out the test bodies against the final tech spec.
+ *            2. Replace each `Deno.test.ignore` with `Deno.test`.
+ *            3. Remove every `// wip` and `// staging` line.
+ *            4. Land impl as a non-test commit descending from the
+ *               Red-gate-cleared marker (philosophies §VIII).
+ *
+ * Goal (from #3):
+ *   - Query string parameter — emits `--<name>` flag.
+ *   - Value lands as `?name=value` in the request URL.
+ *   - Absent flag omits the parameter unless it's marked `required: true`.
+ *
+ * Sibling-spec context: #130 (path templating, just merged) handled the
+ * `path:` block of hey-api's typed input; the query case is the analogous
+ * `query:` block, gated by `parameters[].in === "query"`.
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// wip: import the code-under-test once src/compile/codegen.ts grows the
+// query-parameter wiring.
+// deno-lint-ignore no-explicit-any
+let Codegen: any;
+try {
+  Codegen = await import("../../src/compile/codegen.ts");
+} catch {
+  Codegen = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/parameter-in-query/", import.meta.url),
+);
+
+// staging: keep bindings lint-clean while assertions are still WIP.
+void Codegen;
+void FIXTURE_DIR;
+
+// ---------------------------------------------------------------------------
+// Item A — Required query parameter emits a required CLI flag.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#156 (wip): required query parameter emits a required `--<name>` flag",
+  () => {
+    // staging: fixture: GET /pets?status with `parameters: [{ name: status,
+    // in: query, required: true, schema: { type: string } }]`. Compile
+    // and assert generated subcommand has a `requiredOption("--status ...")`
+    // (or yargs equivalent — pattern-match against the same regex set used
+    // in tests/compile/path-templating_test.ts for required flags).
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item B — Optional query parameter emits an optional flag.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#156 (wip): optional query parameter emits a non-required `--<name>` flag",
+  () => {
+    // staging: fixture: parameter without `required: true`. Assert the
+    // generated subcommand declares a plain `option("--limit ...")` (no
+    // requiredOption / demandOption).
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item C — Provided value threads into the hey-api `query: { ... }` block.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#156 (wip): provided query value threads into hey-api `query: { name: ... }`",
+  () => {
+    // staging: assert the generated handler builds `client.<op>({ query:
+    // { status: opts.status, limit: opts.limit } })` — same structural
+    // probe as #130's `path: { ... }` test. Key presence in the `query:`
+    // block matters; whitespace / quoting does not.
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item D — Absent optional flag omits the key from the query object.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#156 (wip): absent optional flag omits the key from the query object",
+  () => {
+    // staging: invoke the compiled binary without `--limit`. Assert the
+    // outbound request URL does NOT contain `limit=` — the parameter
+    // is omitted when the flag is absent and not required. Exact harness
+    // depends on the compile-and-run integration suite landing.
+    assert(true, "wip");
+  },
+);

--- a/tests/compile/parameter-in-query_test.ts
+++ b/tests/compile/parameter-in-query_test.ts
@@ -1,103 +1,106 @@
 /**
- * Red-Gate scaffold for sw2m/clesty issue #156 — Parameter `in: query`.
+ * Phase 2a Red-Gate suite for sw2m/clesty issue #156 — Parameter `in: query`.
  *
- * staging: tests are stubbed (`Deno.test.ignore`) until #156 grows a tech
- *          spec and the implementation lands. Activation flow:
- *            1. Flesh out the test bodies against the final tech spec.
- *            2. Replace each `Deno.test.ignore` with `Deno.test`.
- *            3. Remove every `// wip` and `// staging` line.
- *            4. Land impl as a non-test commit descending from the
- *               Red-gate-cleared marker (philosophies §VIII).
- *
- * Goal (from #3):
- *   - Query string parameter — emits `--<name>` flag.
- *   - Value lands as `?name=value` in the request URL.
- *   - Absent flag omits the parameter unless it's marked `required: true`.
- *
- * Sibling-spec context: #130 (path templating, just merged) handled the
- * `path:` block of hey-api's typed input; the query case is the analogous
- * `query:` block, gated by `parameters[].in === "query"`.
- *
- * @module
+ * Mirrors the structural shape of #130 (path templating): the test imports
+ * `Codegen.emit(specPath)` from `src/compile/codegen.ts`, runs it against a
+ * fixture, and asserts on substring patterns in the emitted source so the
+ * implementation has room to choose its own commander/yargs/etc. style
+ * without forcing test rewrites.
  */
 
-import { assert } from "@std/assert";
+import { assert, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
-// wip: import the code-under-test once src/compile/codegen.ts grows the
-// query-parameter wiring.
+const mod = await import("../../src/compile/codegen.ts");
 // deno-lint-ignore no-explicit-any
-let Codegen: any;
-try {
-  Codegen = await import("../../src/compile/codegen.ts");
-} catch {
-  Codegen = null;
-}
+const Codegen: any = (mod as Record<string, unknown>).Codegen ?? mod;
 
 const FIXTURE_DIR = fromFileUrl(
   new URL("../fixtures/parameter-in-query/", import.meta.url),
 );
 
-// staging: keep bindings lint-clean while assertions are still WIP.
-void Codegen;
-void FIXTURE_DIR;
+function fixturePath(name: string): string {
+  return `${FIXTURE_DIR}${name}`;
+}
+
+async function emitSource(fixture: string): Promise<string> {
+  const result = await Codegen.emit(fixturePath(fixture));
+  return typeof result === "string" ? result : (result.source ?? "");
+}
+
+function flagsMatching(src: string, re: RegExp): Set<string> {
+  const out = new Set<string>();
+  for (const m of src.matchAll(re)) out.add(m[1]);
+  return out;
+}
+
+const REQUIRED_RE = /requiredOption\(\s*["']--([a-zA-Z0-9_-]+)/g;
+const OPTIONAL_RE = /(?<!required)\.option\(\s*["']--([a-zA-Z0-9_-]+)/g;
 
 // ---------------------------------------------------------------------------
-// Item A — Required query parameter emits a required CLI flag.
+// Item A — required query parameter emits a required CLI flag.
 // ---------------------------------------------------------------------------
 
-Deno.test.ignore(
-  "#156 (wip): required query parameter emits a required `--<name>` flag",
-  () => {
-    // staging: fixture: GET /pets?status with `parameters: [{ name: status,
-    // in: query, required: true, schema: { type: string } }]`. Compile
-    // and assert generated subcommand has a `requiredOption("--status ...")`
-    // (or yargs equivalent — pattern-match against the same regex set used
-    // in tests/compile/path-templating_test.ts for required flags).
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#156): required query parameter emits a required `--<name>` flag", async () => {
+  const src = await emitSource("required-query.yaml");
+  assert(
+    flagsMatching(src, REQUIRED_RE).has("status"),
+    `expected required '--status' flag; src:\n${src}`,
+  );
+});
 
 // ---------------------------------------------------------------------------
-// Item B — Optional query parameter emits an optional flag.
+// Item B — optional query parameter emits a non-required flag.
 // ---------------------------------------------------------------------------
 
-Deno.test.ignore(
-  "#156 (wip): optional query parameter emits a non-required `--<name>` flag",
-  () => {
-    // staging: fixture: parameter without `required: true`. Assert the
-    // generated subcommand declares a plain `option("--limit ...")` (no
-    // requiredOption / demandOption).
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#156): optional query parameter emits a plain `option` flag", async () => {
+  const src = await emitSource("optional-query.yaml");
+  assert(
+    !flagsMatching(src, REQUIRED_RE).has("limit"),
+    `expected '--limit' to NOT be requiredOption; src:\n${src}`,
+  );
+  assert(
+    flagsMatching(src, OPTIONAL_RE).has("limit"),
+    `expected optional '--limit' flag; src:\n${src}`,
+  );
+});
 
 // ---------------------------------------------------------------------------
-// Item C — Provided value threads into the hey-api `query: { ... }` block.
+// Item C — query value threads into hey-api's `query: { ... }` block.
 // ---------------------------------------------------------------------------
 
-Deno.test.ignore(
-  "#156 (wip): provided query value threads into hey-api `query: { name: ... }`",
-  () => {
-    // staging: assert the generated handler builds `client.<op>({ query:
-    // { status: opts.status, limit: opts.limit } })` — same structural
-    // probe as #130's `path: { ... }` test. Key presence in the `query:`
-    // block matters; whitespace / quoting does not.
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#156): query parameter threads into hey-api `query: { ... }` block", async () => {
+  const src = await emitSource("required-query.yaml");
+  const queryBlock = src.match(/query\s*:\s*\{([^}]*)\}/);
+  assert(queryBlock !== null, `expected a 'query: { ... }' block in:\n${src}`);
+  assertStringIncludes(queryBlock[1], "status");
+});
 
 // ---------------------------------------------------------------------------
-// Item D — Absent optional flag omits the key from the query object.
+// Item D — operation with no query parameters omits the `query` block.
 // ---------------------------------------------------------------------------
 
-Deno.test.ignore(
-  "#156 (wip): absent optional flag omits the key from the query object",
-  () => {
-    // staging: invoke the compiled binary without `--limit`. Assert the
-    // outbound request URL does NOT contain `limit=` — the parameter
-    // is omitted when the flag is absent and not required. Exact harness
-    // depends on the compile-and-run integration suite landing.
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#156): operation with no query parameters has no `query: { ... }` block", async () => {
+  const src = await emitSource("no-query.yaml");
+  const queryBlock = src.match(/query\s*:\s*\{([^}]*)\}/);
+  if (queryBlock !== null) {
+    assert(
+      queryBlock[1].trim().length === 0,
+      `expected empty / absent 'query: {}' for no-query op; got: ${queryBlock[0]}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Item E — query and path parameters coexist in the same operation.
+// ---------------------------------------------------------------------------
+
+Deno.test("compile (#156): query + path parameters thread into both blocks independently", async () => {
+  const src = await emitSource("query-and-path.yaml");
+  const pathBlock = src.match(/path\s*:\s*\{([^}]*)\}/);
+  const queryBlock = src.match(/query\s*:\s*\{([^}]*)\}/);
+  assert(pathBlock !== null, `expected 'path: { ... }' block; src:\n${src}`);
+  assert(queryBlock !== null, `expected 'query: { ... }' block; src:\n${src}`);
+  assertStringIncludes(pathBlock[1], "id");
+  assertStringIncludes(queryBlock[1], "include");
+});

--- a/tests/fixtures/parameter-in-query/no-query.yaml
+++ b/tests/fixtures/parameter-in-query/no-query.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+info:
+  title: no query
+  version: 0.0.1
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-in-query/optional-query.yaml
+++ b/tests/fixtures/parameter-in-query/optional-query.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: optional query
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-in-query/query-and-path.yaml
+++ b/tests/fixtures/parameter-in-query/query-and-path.yaml
@@ -1,0 +1,25 @@
+openapi: 3.0.3
+info:
+  title: query + path
+  version: 0.0.1
+paths:
+  /pets/{id}:
+    get:
+      operationId: getPet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: include
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-in-query/required-query.yaml
+++ b/tests/fixtures/parameter-in-query/required-query.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: required query
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: status
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
Closes the codegen portion of #156 — Parameter \`in: query\`.

Staged per VSDD §II:
1. **Tests-only commits** — replace the original WIP scaffold (commit e8d38a6) with the real Red-Gate suite + four fixtures (commit 46a154f, marker cleared at this SHA + the fixture-add commit ab5ba4c).
2. **Implementation commit** (521dab8) — extends \`src/compile/codegen.ts\` with \`paramsByLocation(parameters, loc)\`, a \`ParamGroup\` shape, and emits \`requiredOption\` / \`option\` lines per group, threading values into the matching hey-api block (\`path\`, \`query\`, \`headers\`, \`cookies\`). Descends from the cleared marker — Non-test-blocker confirms.

Sibling PRs #471 (#159 cookie) and #473 (#157 header) ride on this codegen plumbing; they need only fixture + test changes.

## Verification
\`deno task test\` — **95 passed | 0 failed | 52 ignored**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)