### PR TITLE
tests(#157): Parameter in: header

### DIFF
--- a/tests/compile/parameter-in-header_test.ts
+++ b/tests/compile/parameter-in-header_test.ts
@@ -1,65 +1,75 @@
 /**
- * Red-Gate scaffold for sw2m/clesty issue #157 — Parameter `in: header`.
+ * Phase 2a Red-Gate suite for sw2m/clesty issue #157 — Parameter `in: header`.
  *
- * staging: tests are stubbed (`Deno.test.ignore`) until #157 grows a tech
- *          spec and the implementation lands. Activation flow:
- *            1. Flesh out the test bodies against the final tech spec.
- *            2. Replace each `Deno.test.ignore` with `Deno.test`.
- *            3. Remove every `// wip` and `// staging` line.
- *            4. Land impl as a non-test commit descending from the
- *               Red-gate-cleared marker (philosophies §VIII).
- *
- * @module
+ * Mirrors #156's query suite: the codegen now handles all four parameter
+ * locations uniformly (path / query / header / cookie). This file asserts
+ * the header-specific surface — `--<name>` flags + threading into the
+ * hey-api `headers: { ... }` block.
  */
 
-import { assert } from "@std/assert";
+import { assert, assertStringIncludes } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
-// wip: import the code-under-test once the relevant src/compile module
-// grows the wiring for Parameter `in: header`.
+const mod = await import("../../src/compile/codegen.ts");
 // deno-lint-ignore no-explicit-any
-let Codegen: any;
-try {
-  Codegen = await import("../../src/compile/codegen.ts");
-} catch {
-  Codegen = null;
-}
+const Codegen: any = (mod as Record<string, unknown>).Codegen ?? mod;
 
 const FIXTURE_DIR = fromFileUrl(
   new URL("../fixtures/parameter-in-header/", import.meta.url),
 );
 
-// staging: keep bindings lint-clean while assertions are still WIP.
-void Codegen;
-void FIXTURE_DIR;
+function fixturePath(name: string): string {
+  return `${FIXTURE_DIR}${name}`;
+}
 
-// ---------------------------------------------------------------------------
-// Item A — primary contract.
-// ---------------------------------------------------------------------------
+async function emitSource(fixture: string): Promise<string> {
+  const result = await Codegen.emit(fixturePath(fixture));
+  return typeof result === "string" ? result : (result.source ?? "");
+}
 
-Deno.test.ignore(
-  "#157 (wip): Parameter `in: header` — primary contract",
-  () => {
-    // staging: replace this stub once the tech spec on #157 pins down the
-    // exact contract. The shape mirrors the sibling Red-Gate suites
-    // (e.g. tests/compile/responses_test.ts) — graceful import of the
-    // code-under-test, fixture fed in, structural assertion on the
-    // emitted source / behaviour.
-    assert(true, "wip");
-  },
-);
+function flagsMatching(src: string, re: RegExp): Set<string> {
+  const out = new Set<string>();
+  for (const m of src.matchAll(re)) out.add(m[1]);
+  return out;
+}
 
-// ---------------------------------------------------------------------------
-// Item B — refusal / edge case (if applicable per the to-be-written spec).
-// ---------------------------------------------------------------------------
+const REQUIRED_RE = /requiredOption\(\s*["']--([a-zA-Z0-9_-]+)/g;
+const OPTIONAL_RE = /(?<!required)\.option\(\s*["']--([a-zA-Z0-9_-]+)/g;
 
-Deno.test.ignore(
-  "#157 (wip): Parameter `in: header` — refusal / edge case",
-  () => {
-    // staging: replace this stub once the tech spec on #157 pins the
-    // refusal / edge-case shape. If the spec turns out to be acceptance-
-    // only (no refusal cases), drop this test and update the activation
-    // checklist in the PR body.
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#157): required header parameter emits required `--<name>` flag", async () => {
+  const src = await emitSource("required-header.yaml");
+  assert(
+    flagsMatching(src, REQUIRED_RE).has("X-Tenant"),
+    `expected required '--X-Tenant' flag; src:\n${src}`,
+  );
+});
+
+Deno.test("compile (#157): optional header parameter emits a plain `option` flag", async () => {
+  const src = await emitSource("optional-header.yaml");
+  assert(
+    !flagsMatching(src, REQUIRED_RE).has("X-Trace-Id"),
+    `expected '--X-Trace-Id' to NOT be requiredOption; src:\n${src}`,
+  );
+  assert(
+    flagsMatching(src, OPTIONAL_RE).has("X-Trace-Id"),
+    `expected optional '--X-Trace-Id' flag; src:\n${src}`,
+  );
+});
+
+Deno.test("compile (#157): header parameter threads into hey-api `headers: { ... }` block", async () => {
+  const src = await emitSource("required-header.yaml");
+  const block = src.match(/headers\s*:\s*\{([^}]*)\}/);
+  assert(block !== null, `expected a 'headers: { ... }' block; src:\n${src}`);
+  assertStringIncludes(block[1], "X-Tenant");
+});
+
+Deno.test("compile (#157): operation with no header parameters has no `headers` block", async () => {
+  const src = await emitSource("no-header.yaml");
+  const block = src.match(/headers\s*:\s*\{([^}]*)\}/);
+  if (block !== null) {
+    assert(
+      block[1].trim().length === 0,
+      `expected empty/absent 'headers: {}' for no-header op; got: ${block[0]}`,
+    );
+  }
+});

--- a/tests/compile/parameter-in-header_test.ts
+++ b/tests/compile/parameter-in-header_test.ts
@@ -1,0 +1,65 @@
+/**
+ * Red-Gate scaffold for sw2m/clesty issue #157 — Parameter `in: header`.
+ *
+ * staging: tests are stubbed (`Deno.test.ignore`) until #157 grows a tech
+ *          spec and the implementation lands. Activation flow:
+ *            1. Flesh out the test bodies against the final tech spec.
+ *            2. Replace each `Deno.test.ignore` with `Deno.test`.
+ *            3. Remove every `// wip` and `// staging` line.
+ *            4. Land impl as a non-test commit descending from the
+ *               Red-gate-cleared marker (philosophies §VIII).
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// wip: import the code-under-test once the relevant src/compile module
+// grows the wiring for Parameter `in: header`.
+// deno-lint-ignore no-explicit-any
+let Codegen: any;
+try {
+  Codegen = await import("../../src/compile/codegen.ts");
+} catch {
+  Codegen = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/parameter-in-header/", import.meta.url),
+);
+
+// staging: keep bindings lint-clean while assertions are still WIP.
+void Codegen;
+void FIXTURE_DIR;
+
+// ---------------------------------------------------------------------------
+// Item A — primary contract.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#157 (wip): Parameter `in: header` — primary contract",
+  () => {
+    // staging: replace this stub once the tech spec on #157 pins down the
+    // exact contract. The shape mirrors the sibling Red-Gate suites
+    // (e.g. tests/compile/responses_test.ts) — graceful import of the
+    // code-under-test, fixture fed in, structural assertion on the
+    // emitted source / behaviour.
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item B — refusal / edge case (if applicable per the to-be-written spec).
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#157 (wip): Parameter `in: header` — refusal / edge case",
+  () => {
+    // staging: replace this stub once the tech spec on #157 pins the
+    // refusal / edge-case shape. If the spec turns out to be acceptance-
+    // only (no refusal cases), drop this test and update the activation
+    // checklist in the PR body.
+    assert(true, "wip");
+  },
+);

--- a/tests/fixtures/parameter-in-header/no-header.yaml
+++ b/tests/fixtures/parameter-in-header/no-header.yaml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+info:
+  title: no header
+  version: 0.0.1
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-in-header/optional-header.yaml
+++ b/tests/fixtures/parameter-in-header/optional-header.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: optional header
+  version: 0.0.1
+paths:
+  /tenants:
+    get:
+      operationId: listTenants
+      parameters:
+        - name: X-Trace-Id
+          in: header
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-in-header/required-header.yaml
+++ b/tests/fixtures/parameter-in-header/required-header.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: required header
+  version: 0.0.1
+paths:
+  /tenants:
+    get:
+      operationId: listTenants
+      parameters:
+        - name: X-Tenant
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
Closes #157. Tests-only — codegen plumbing already landed in #469.

`deno task test` passes (4 new tests, 99 total). 🤖 Generated with Claude Code