### PR TITLE
tests + impl(#163): Parameter deprecated

### DIFF
--- a/src/compile/codegen.ts
+++ b/src/compile/codegen.ts
@@ -93,7 +93,7 @@ function pathVars(template: string): string[] {
   return out;
 }
 
-type ParamDecl = { name: string; in: string; required?: boolean };
+type ParamDecl = { name: string; in: string; required?: boolean; deprecated?: boolean };
 
 function paramsByLocation(
   parameters: unknown,
@@ -101,6 +101,14 @@ function paramsByLocation(
 ): ParamDecl[] {
   if (!Array.isArray(parameters)) return [];
   return (parameters as ParamDecl[]).filter((p) => p && p.in === loc && typeof p.name === "string");
+}
+
+/** Build the description string for a parameter's CLI option. Includes the
+ * literal "(DEPRECATED)" token when `p.deprecated` is true so users
+ * reading `--help` see the warning without consulting the OpenAPI doc. */
+function describe(p: ParamDecl, role: string, block: string): string {
+  const prefix = p.deprecated === true ? "(DEPRECATED) " : "";
+  return `${prefix}${role} ${block} parameter ${p.name}`;
 }
 
 function kebab(opId: string): string {
@@ -131,12 +139,12 @@ function sourceFor(opId: string, groups: ParamGroup[]): string {
   for (const g of groups) {
     for (const p of g.required) {
       flagLines.push(
-        `  .requiredOption("--${p.name} <${p.name}>", "required ${g.block} parameter ${p.name}")`,
+        `  .requiredOption("--${p.name} <${p.name}>", "${describe(p, "required", g.block)}")`,
       );
     }
     for (const p of g.optional) {
       flagLines.push(
-        `  .option("--${p.name} <${p.name}>", "optional ${g.block} parameter ${p.name}")`,
+        `  .option("--${p.name} <${p.name}>", "${describe(p, "optional", g.block)}")`,
       );
     }
     const all = [...g.required, ...g.optional];

--- a/tests/compile/parameter-deprecated_test.ts
+++ b/tests/compile/parameter-deprecated_test.ts
@@ -1,65 +1,57 @@
 /**
- * Red-Gate scaffold for sw2m/clesty issue #163 — Parameter `deprecated`.
+ * Phase 2a Red-Gate suite for sw2m/clesty issue #163 — Parameter `deprecated`.
  *
- * staging: tests are stubbed (`Deno.test.ignore`) until #163 grows a tech
- *          spec and the implementation lands. Activation flow:
- *            1. Flesh out the test bodies against the final tech spec.
- *            2. Replace each `Deno.test.ignore` with `Deno.test`.
- *            3. Remove every `// wip` and `// staging` line.
- *            4. Land impl as a non-test commit descending from the
- *               Red-gate-cleared marker (philosophies §VIII).
- *
- * @module
+ * `deprecated: true` on a parameter must surface in the generated CLI so a
+ * user reading `--help` learns the flag is on the way out without having
+ * to read the OpenAPI doc directly. The exact rendering is part of the
+ * codegen contract; this test pins down the structural shape: the
+ * generated source contains the literal string "(DEPRECATED)" inside the
+ * option's description for any deprecated parameter.
  */
 
 import { assert } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
-// wip: import the code-under-test once the relevant src/compile module
-// grows the wiring for Parameter `deprecated`.
+const mod = await import("../../src/compile/codegen.ts");
 // deno-lint-ignore no-explicit-any
-let Codegen: any;
-try {
-  Codegen = await import("../../src/compile/codegen.ts");
-} catch {
-  Codegen = null;
-}
+const Codegen: any = (mod as Record<string, unknown>).Codegen ?? mod;
 
 const FIXTURE_DIR = fromFileUrl(
   new URL("../fixtures/parameter-deprecated/", import.meta.url),
 );
 
-// staging: keep bindings lint-clean while assertions are still WIP.
-void Codegen;
-void FIXTURE_DIR;
+async function emitSource(fixture: string): Promise<string> {
+  const result = await Codegen.emit(`${FIXTURE_DIR}${fixture}`);
+  return typeof result === "string" ? result : (result.source ?? "");
+}
 
-// ---------------------------------------------------------------------------
-// Item A — primary contract.
-// ---------------------------------------------------------------------------
+Deno.test("compile (#163): deprecated query parameter description carries (DEPRECATED) marker", async () => {
+  const src = await emitSource("deprecated-query.yaml");
+  // The deprecation marker should be on the line that declares the flag,
+  // not just somewhere in the source. Match either an `option(...)` or
+  // `requiredOption(...)` line whose description contains DEPRECATED.
+  const match = src.match(/(?:requiredOption|option)\(\s*["']--legacy[^)]*DEPRECATED/i);
+  assert(
+    match !== null,
+    `expected '--legacy' option's description to include DEPRECATED; src:\n${src}`,
+  );
+});
 
-Deno.test.ignore(
-  "#163 (wip): Parameter `deprecated` — primary contract",
-  () => {
-    // staging: replace this stub once the tech spec on #163 pins down the
-    // exact contract. The shape mirrors the sibling Red-Gate suites
-    // (e.g. tests/compile/responses_test.ts) — graceful import of the
-    // code-under-test, fixture fed in, structural assertion on the
-    // emitted source / behaviour.
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#163): non-deprecated parameter has no DEPRECATED marker", async () => {
+  const src = await emitSource("active-query.yaml");
+  // Control fixture — no parameter has deprecated: true. Source should
+  // contain no DEPRECATED tokens at all.
+  assert(
+    !/DEPRECATED/i.test(src),
+    `expected no DEPRECATED token for active parameters; src:\n${src}`,
+  );
+});
 
-// ---------------------------------------------------------------------------
-// Item B — refusal / edge case (if applicable per the to-be-written spec).
-// ---------------------------------------------------------------------------
-
-Deno.test.ignore(
-  "#163 (wip): Parameter `deprecated` — refusal / edge case",
-  () => {
-    // staging: replace this stub once the tech spec on #163 pins the
-    // refusal / edge-case shape. If the spec turns out to be acceptance-
-    // only (no refusal cases), drop this test and update the activation
-    // checklist in the PR body.
-    assert(true, "wip");
-  },
-);
+Deno.test("compile (#163): deprecated header parameter also marked", async () => {
+  const src = await emitSource("deprecated-header.yaml");
+  const match = src.match(/(?:requiredOption|option)\(\s*["']--X-Old[^)]*DEPRECATED/i);
+  assert(
+    match !== null,
+    `expected '--X-Old' header option to include DEPRECATED; src:\n${src}`,
+  );
+});

--- a/tests/compile/parameter-deprecated_test.ts
+++ b/tests/compile/parameter-deprecated_test.ts
@@ -1,0 +1,65 @@
+/**
+ * Red-Gate scaffold for sw2m/clesty issue #163 — Parameter `deprecated`.
+ *
+ * staging: tests are stubbed (`Deno.test.ignore`) until #163 grows a tech
+ *          spec and the implementation lands. Activation flow:
+ *            1. Flesh out the test bodies against the final tech spec.
+ *            2. Replace each `Deno.test.ignore` with `Deno.test`.
+ *            3. Remove every `// wip` and `// staging` line.
+ *            4. Land impl as a non-test commit descending from the
+ *               Red-gate-cleared marker (philosophies §VIII).
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// wip: import the code-under-test once the relevant src/compile module
+// grows the wiring for Parameter `deprecated`.
+// deno-lint-ignore no-explicit-any
+let Codegen: any;
+try {
+  Codegen = await import("../../src/compile/codegen.ts");
+} catch {
+  Codegen = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/parameter-deprecated/", import.meta.url),
+);
+
+// staging: keep bindings lint-clean while assertions are still WIP.
+void Codegen;
+void FIXTURE_DIR;
+
+// ---------------------------------------------------------------------------
+// Item A — primary contract.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#163 (wip): Parameter `deprecated` — primary contract",
+  () => {
+    // staging: replace this stub once the tech spec on #163 pins down the
+    // exact contract. The shape mirrors the sibling Red-Gate suites
+    // (e.g. tests/compile/responses_test.ts) — graceful import of the
+    // code-under-test, fixture fed in, structural assertion on the
+    // emitted source / behaviour.
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item B — refusal / edge case (if applicable per the to-be-written spec).
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#163 (wip): Parameter `deprecated` — refusal / edge case",
+  () => {
+    // staging: replace this stub once the tech spec on #163 pins the
+    // refusal / edge-case shape. If the spec turns out to be acceptance-
+    // only (no refusal cases), drop this test and update the activation
+    // checklist in the PR body.
+    assert(true, "wip");
+  },
+);

--- a/tests/fixtures/parameter-deprecated/active-query.yaml
+++ b/tests/fixtures/parameter-deprecated/active-query.yaml
@@ -1,0 +1,20 @@
+openapi: 3.0.3
+info:
+  title: active query
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-deprecated/deprecated-header.yaml
+++ b/tests/fixtures/parameter-deprecated/deprecated-header.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: deprecated header
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: X-Old
+          in: header
+          deprecated: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object

--- a/tests/fixtures/parameter-deprecated/deprecated-query.yaml
+++ b/tests/fixtures/parameter-deprecated/deprecated-query.yaml
@@ -1,0 +1,21 @@
+openapi: 3.0.3
+info:
+  title: deprecated query
+  version: 0.0.1
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      parameters:
+        - name: legacy
+          in: query
+          deprecated: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
Closes #163. Codegen prefixes `(DEPRECATED)` to the CLI option description for any parameter with `deprecated: true`. Tests-only commit cleared the marker at ee3a40f; impl commit (bde9d19) descends.

`deno task test` passes (106 total). 🤖 Claude Code