### PR TITLE
tests(#267): Red-Gate scaffold for `components.schemas` (wip)

### DIFF
--- a/tests/compile/components-schemas_test.ts
+++ b/tests/compile/components-schemas_test.ts
@@ -1,0 +1,65 @@
+/**
+ * Red-Gate scaffold for sw2m/clesty issue #267 — `components.schemas`.
+ *
+ * staging: tests are stubbed (`Deno.test.ignore`) until #267 grows a tech
+ *          spec and the implementation lands. Activation flow:
+ *            1. Flesh out the test bodies against the final tech spec.
+ *            2. Replace each `Deno.test.ignore` with `Deno.test`.
+ *            3. Remove every `// wip` and `// staging` line.
+ *            4. Land impl as a non-test commit descending from the
+ *               Red-gate-cleared marker (philosophies §VIII).
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// wip: import the code-under-test once the relevant src/compile module
+// grows the wiring for `components.schemas`.
+// deno-lint-ignore no-explicit-any
+let Codegen: any;
+try {
+  Codegen = await import("../../src/compile/codegen.ts");
+} catch {
+  Codegen = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/components-schemas/", import.meta.url),
+);
+
+// staging: keep bindings lint-clean while assertions are still WIP.
+void Codegen;
+void FIXTURE_DIR;
+
+// ---------------------------------------------------------------------------
+// Item A — primary contract.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#267 (wip): `components.schemas` — primary contract",
+  () => {
+    // staging: replace this stub once the tech spec on #267 pins down the
+    // exact contract. The shape mirrors the sibling Red-Gate suites
+    // (e.g. tests/compile/responses_test.ts) — graceful import of the
+    // code-under-test, fixture fed in, structural assertion on the
+    // emitted source / behaviour.
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item B — refusal / edge case (if applicable per the to-be-written spec).
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#267 (wip): `components.schemas` — refusal / edge case",
+  () => {
+    // staging: replace this stub once the tech spec on #267 pins the
+    // refusal / edge-case shape. If the spec turns out to be acceptance-
+    // only (no refusal cases), drop this test and update the activation
+    // checklist in the PR body.
+    assert(true, "wip");
+  },
+);


### PR DESCRIPTION
**Draft / Red-Gate scaffold** for #267 — `components.schemas`.

Held in draft so the VSDD gates don't fire prematurely. Activation when the tech spec on #267 lands:
1. Flesh out the stub test bodies against the final tech spec.
2. Replace each `Deno.test.ignore` with `Deno.test`.
3. Remove every `// wip` and `// staging` line.
4. Mark `ready_for_review` so the Red-conditions gate posts the cleared marker.
5. Push impl as a non-test commit descending from that marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)