### PR TITLE
tests(#399): Red-Gate scaffold for 3.1 `type: "null"` alone (wip)

### DIFF
--- a/tests/compile/3-1-type-null-alone_test.ts
+++ b/tests/compile/3-1-type-null-alone_test.ts
@@ -1,0 +1,65 @@
+/**
+ * Red-Gate scaffold for sw2m/clesty issue #399 — 3.1 `type: "null"` alone.
+ *
+ * staging: tests are stubbed (`Deno.test.ignore`) until #399 grows a tech
+ *          spec and the implementation lands. Activation flow:
+ *            1. Flesh out the test bodies against the final tech spec.
+ *            2. Replace each `Deno.test.ignore` with `Deno.test`.
+ *            3. Remove every `// wip` and `// staging` line.
+ *            4. Land impl as a non-test commit descending from the
+ *               Red-gate-cleared marker (philosophies §VIII).
+ *
+ * @module
+ */
+
+import { assert } from "@std/assert";
+import { fromFileUrl } from "@std/path";
+
+// wip: import the code-under-test once the relevant src/compile module
+// grows the wiring for 3.1 `type: "null"` alone.
+// deno-lint-ignore no-explicit-any
+let Codegen: any;
+try {
+  Codegen = await import("../../src/compile/codegen.ts");
+} catch {
+  Codegen = null;
+}
+
+const FIXTURE_DIR = fromFileUrl(
+  new URL("../fixtures/3-1-type-null-alone/", import.meta.url),
+);
+
+// staging: keep bindings lint-clean while assertions are still WIP.
+void Codegen;
+void FIXTURE_DIR;
+
+// ---------------------------------------------------------------------------
+// Item A — primary contract.
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#399 (wip): 3.1 `type: "null"` alone — primary contract",
+  () => {
+    // staging: replace this stub once the tech spec on #399 pins down the
+    // exact contract. The shape mirrors the sibling Red-Gate suites
+    // (e.g. tests/compile/responses_test.ts) — graceful import of the
+    // code-under-test, fixture fed in, structural assertion on the
+    // emitted source / behaviour.
+    assert(true, "wip");
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Item B — refusal / edge case (if applicable per the to-be-written spec).
+// ---------------------------------------------------------------------------
+
+Deno.test.ignore(
+  "#399 (wip): 3.1 `type: "null"` alone — refusal / edge case",
+  () => {
+    // staging: replace this stub once the tech spec on #399 pins the
+    // refusal / edge-case shape. If the spec turns out to be acceptance-
+    // only (no refusal cases), drop this test and update the activation
+    // checklist in the PR body.
+    assert(true, "wip");
+  },
+);

--- a/tests/compile/3-1-type-null-alone_test.ts
+++ b/tests/compile/3-1-type-null-alone_test.ts
@@ -1,13 +1,13 @@
 /**
- * Red-Gate scaffold for sw2m/clesty issue #399 — 3.1 `type: "null"` alone.
+ * Red-Gate scaffold for sw2m/clesty issue #399 — 3.1 type: null alone.
  *
- * staging: tests are stubbed (`Deno.test.ignore`) until #399 grows a tech
- *          spec and the implementation lands. Activation flow:
+ * staging: tests are stubbed until #399 grows a tech spec and the
+ *          implementation lands. Activation flow:
  *            1. Flesh out the test bodies against the final tech spec.
- *            2. Replace each `Deno.test.ignore` with `Deno.test`.
- *            3. Remove every `// wip` and `// staging` line.
+ *            2. Replace each Deno.test.ignore with Deno.test.
+ *            3. Remove every // wip and // staging line.
  *            4. Land impl as a non-test commit descending from the
- *               Red-gate-cleared marker (philosophies §VIII).
+ *               Red-gate-cleared marker (philosophies VIII).
  *
  * @module
  */
@@ -16,7 +16,7 @@ import { assert } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 
 // wip: import the code-under-test once the relevant src/compile module
-// grows the wiring for 3.1 `type: "null"` alone.
+// grows the wiring for this issue.
 // deno-lint-ignore no-explicit-any
 let Codegen: any;
 try {
@@ -38,28 +38,21 @@ void FIXTURE_DIR;
 // ---------------------------------------------------------------------------
 
 Deno.test.ignore(
-  "#399 (wip): 3.1 `type: "null"` alone — primary contract",
+  "#399 (wip): primary contract",
   () => {
-    // staging: replace this stub once the tech spec on #399 pins down the
-    // exact contract. The shape mirrors the sibling Red-Gate suites
-    // (e.g. tests/compile/responses_test.ts) — graceful import of the
-    // code-under-test, fixture fed in, structural assertion on the
-    // emitted source / behaviour.
+    // staging: replace once #399 pins the contract.
     assert(true, "wip");
   },
 );
 
 // ---------------------------------------------------------------------------
-// Item B — refusal / edge case (if applicable per the to-be-written spec).
+// Item B — refusal / edge case.
 // ---------------------------------------------------------------------------
 
 Deno.test.ignore(
-  "#399 (wip): 3.1 `type: "null"` alone — refusal / edge case",
+  "#399 (wip): refusal / edge case",
   () => {
-    // staging: replace this stub once the tech spec on #399 pins the
-    // refusal / edge-case shape. If the spec turns out to be acceptance-
-    // only (no refusal cases), drop this test and update the activation
-    // checklist in the PR body.
+    // staging: replace once #399 pins the refusal shape.
     assert(true, "wip");
   },
 );


### PR DESCRIPTION
**Draft / Red-Gate scaffold** for #399 — 3.1 `type: "null"` alone.

Held in draft so the VSDD gates don't fire prematurely. Activation when the tech spec on #399 lands:
1. Flesh out the stub test bodies against the final tech spec.
2. Replace each `Deno.test.ignore` with `Deno.test`.
3. Remove every `// wip` and `// staging` line.
4. Mark `ready_for_review` so the Red-conditions gate posts the cleared marker.
5. Push impl as a non-test commit descending from that marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)