### PR TITLE
chore: vsdd-issues docstring reflects Phase 1c verdict gate

### DIFF
--- a/.github/workflows/vsdd-issues.yml
+++ b/.github/workflows/vsdd-issues.yml
@@ -1,9 +1,13 @@
 name: VSDD Issue Review (Phase 1c)
 
 # Thin caller — delegates to sw2m/philosophies. Adversarial spec review
-# (Gemini + Claude) on issue open/edit/assigned. Advisory only — never
-# gates. Org-membership and ownership-by-assignment are enforced inside
-# the called workflow.
+# (Gemini + Claude) on issue open/edit/assigned. Each reviewer's verdict
+# is embedded as HTML-comment frontmatter at the top of its review
+# comment; promote.yml's `phase-1c-clearance` job parses those verdicts
+# and BLOCKS goal→tech / tech→PR promotion when either reviewer's
+# latest verdict is `fail` or stale (older than the issue's last edit).
+# Org-membership and ownership-by-assignment are enforced inside the
+# called workflow.
 
 on:
   issues:


### PR DESCRIPTION
Cosmetic update to the thin-caller docstring in `.github/workflows/vsdd-issues.yml`.

Behavior change is already in effect because the thin caller `uses: sw2m/philosophies/.github/workflows/issue-review.yml@main`. The upstream change in [sw2m/philosophies#80](https://github.com/sw2m/philosophies/pull/80) makes Phase 1c verdicts gate goal→tech / tech→PR promotion via `promote.yml`'s `phase-1c-clearance` job. The clesty thin-caller's docstring still claimed "Advisory only — never gates", which is no longer accurate. This PR brings the docstring back in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)